### PR TITLE
Add request duration to access logs

### DIFF
--- a/troncos/frameworks/asgi/middleware.py
+++ b/troncos/frameworks/asgi/middleware.py
@@ -1,5 +1,6 @@
 import collections
 import logging
+import time
 from typing import Any, Awaitable, Callable
 
 from opentelemetry import trace
@@ -123,6 +124,7 @@ class AsgiLoggingMiddleware:
         path = scope.get("path")
         http_version = scope.get("http_version")
         status = [0]
+        start_time = time.time()
 
         async def wrapped_send(message: dict[str, Any]) -> None:
             if "status" in message:
@@ -143,6 +145,7 @@ class AsgiLoggingMiddleware:
                         "http_path": path,
                         "http_version": http_version,
                         "http_status_code": status[0],
+                        "duration": f"{time.time()-start_time:.6f}",
                     },
                 )
 
@@ -158,6 +161,7 @@ class AsgiLoggingMiddleware:
                     "http_path": path,
                     "http_version": http_version,
                     "http_status_code": 500,
+                    "duration": f"{time.time()-start_time:.6f}",
                 },
             )
             raise e

--- a/troncos/logs/formatters.py
+++ b/troncos/logs/formatters.py
@@ -173,6 +173,7 @@ class LogfmtFormatter(logging.Formatter):
                 ("http_path", "http_path"),
                 ("http_version", "http_version"),
                 ("http_status_code", "http_status_code"),
+                ("duration", "duration"),
                 ("trace_id", "trace_id"),
                 ("span_id", "span_id"),
                 ("msg", "msg"),
@@ -276,12 +277,14 @@ class PrettyFormatter(logging.Formatter):
             and hasattr(rc, "http_method")
             and hasattr(rc, "http_path")
             and hasattr(rc, "http_status_code")
+            and hasattr(rc, "duration")
         ):
             rc.message = f"{rc.http_client_addr}"  # type: ignore[attr-defined]
             rc.message += " - "
             rc.message += f"{rc.http_method}"  # type: ignore[attr-defined]
             rc.message += f" {rc.http_path}"  # type: ignore[attr-defined]
             rc.message += f" {rc.http_status_code}"  # type: ignore[attr-defined]
+            rc.message += f" {rc.duration}"  # type: ignore[attr-defined]
         if hasattr(rc, "trace_id"):
             rc.message += f" [trace_id: {rc.trace_id}]"  # type: ignore[attr-defined]
 


### PR DESCRIPTION
Using Troncos in Salsa and now starting to build new dashboards in Grafana I think this feature would be nice to have.
We get Prometheus metrics on request duration, and we can look at traces/spans that are long. But with metrics we can't backtrack to find a specific slow request and with traces we're combined with Tienda-data so we can't filter at where Salsa was slow.

Adding this would allow us to make dashboards that would light up the slow queries and we could follow the traceID links to drill down into why.

Implementation wise the naming and way of doing this is inspired by two things, the [gunicorn logging in Tienda](https://github.com/kolonialno/tienda/blob/main/tienda/gunicorn/config.py#L78) and this [asgi logger framework I found](https://github.com/Kludex/asgi-logger/blob/main/asgi_logger/middleware.py#L92).

Open to doing it differently as I don't know the Troncos way of things, but figured I'd just do a quick PR to test it first.
At least it works on my machine :smile: :
```
logfmt:
time="2022-11-07T11:18:30.760788" level="INFO" logger="salsa.access" http_client_addr="127.0.0.1:57630" http_method="GET" http_path="/api/v1/search/products/" http_version="1.1" http_status_code="200" duration="0.042149"

pretty:
INFO:      127.0.0.1:57118 - GET /api/v1/search/products/ 200 0.018725
```