### PR TITLE
Make translate_span a little faster

### DIFF
--- a/troncos/tracing/_writer.py
+++ b/troncos/tracing/_writer.py
@@ -6,7 +6,7 @@ from opentelemetry.sdk.resources import Resource
 
 from ._enums import Exporter
 from ._otel import get_otel_span_processors
-from ._span import translate_span, default_ignore_attrs
+from ._span import default_ignore_attrs, translate_span
 
 
 class OTELWriter(TraceWriter):


### PR DESCRIPTION
Using py-spy, it looks like the previous version spent some time doing

list(default_resource.attributes.keys()) every time it was called.

It seems this can be done once in the OTELWriter constructor instead. Also, I think we can make it a set instead of a list (I believe `a in my_set` is a bit quicker than `a in my_list`).

Does this commit include tests to verify the speed increase? Nah... 🤷