### PR TITLE
✨ feature(structlog): Add extra_processors and extra_loggers

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -582,7 +582,7 @@ testing = ["Django (<3.1)", "attrs", "colorama", "docopt", "pytest (<7.0.0)"]
 
 [[package]]
 name = "jsonschema"
-version = "4.18.0"
+version = "4.18.2"
 description = "An implementation of JSON Schema validation for Python"
 category = "main"
 optional = false
@@ -982,7 +982,7 @@ testing = ["argcomplete", "attrs (>=19.2.0)", "hypothesis (>=3.56)", "mock", "no
 
 [[package]]
 name = "pytest-asyncio"
-version = "0.21.0"
+version = "0.21.1"
 description = "Pytest support for asyncio"
 category = "dev"
 optional = false
@@ -1099,8 +1099,8 @@ python-versions = ">=3.8"
 name = "sentry-sdk"
 version = "1.28.0"
 description = "Python client for Sentry (https://sentry.io)"
-category = "dev"
-optional = false
+category = "main"
+optional = true
 python-versions = "*"
 
 [package.dependencies]
@@ -1221,7 +1221,7 @@ full = ["httpx (>=0.22.0)", "itsdangerous", "jinja2", "python-multipart", "pyyam
 name = "structlog"
 version = "23.1.0"
 description = "Structured Logging for Python"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.7"
 
@@ -1235,8 +1235,8 @@ typing = ["mypy", "rich", "twisted"]
 name = "structlog-sentry"
 version = "2.0.3"
 description = "Sentry integration for structlog"
-category = "dev"
-optional = false
+category = "main"
+optional = true
 python-versions = ">=3.7,<4.0"
 
 [package.dependencies]
@@ -1354,7 +1354,7 @@ python-versions = ">=3.4"
 
 [[package]]
 name = "zipp"
-version = "3.16.0"
+version = "3.16.1"
 description = "Backport of pathlib-compatible object wrapper for zip files"
 category = "main"
 optional = false
@@ -1366,11 +1366,12 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 
 [extras]
 grpc = ["opentelemetry-exporter-otlp-proto-grpc"]
+sentry = ["structlog-sentry"]
 
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.10,<4.0"
-content-hash = "6a024cc728bb10e0609675f75ddc3abf84c193a5a6f24f66df3fbe320d852108"
+content-hash = "3dd5942633e4bd20766118d3efb03817d330fc0db491901c1c61bba511c3ad2f"
 
 [metadata.files]
 amqp = [
@@ -1861,8 +1862,8 @@ jedi = [
     {file = "jedi-0.18.2.tar.gz", hash = "sha256:bae794c30d07f6d910d32a7048af09b5a39ed740918da923c6b780790ebac612"},
 ]
 jsonschema = [
-    {file = "jsonschema-4.18.0-py3-none-any.whl", hash = "sha256:b508dd6142bd03f4c3670534c80af68cd7bbff9ea830b9cf2625d4a3c49ddf60"},
-    {file = "jsonschema-4.18.0.tar.gz", hash = "sha256:8caf5b57a990a98e9b39832ef3cb35c176fe331414252b6e1b26fd5866f891a4"},
+    {file = "jsonschema-4.18.2-py3-none-any.whl", hash = "sha256:159fdff1443b4c5ed900d4eeac6b928a3485f4aff5fba6edd1e25cd66bb46b39"},
+    {file = "jsonschema-4.18.2.tar.gz", hash = "sha256:af3855bfa30e83b2200a5fe12ab5eb92460e4d3b8e4efd34094aa637f7272a87"},
 ]
 jsonschema-specifications = [
     {file = "jsonschema_specifications-2023.6.1-py3-none-any.whl", hash = "sha256:3d2b82663aff01815f744bb5c7887e2121a63399b49b104a3c96145474d091d7"},
@@ -2065,8 +2066,8 @@ pytest = [
     {file = "pytest-7.4.0.tar.gz", hash = "sha256:b4bf8c45bd59934ed84001ad51e11b4ee40d40a1229d2c79f9c592b0a3f6bd8a"},
 ]
 pytest-asyncio = [
-    {file = "pytest-asyncio-0.21.0.tar.gz", hash = "sha256:2b38a496aef56f56b0e87557ec313e11e1ab9276fc3863f6a7be0f1d0e415e1b"},
-    {file = "pytest_asyncio-0.21.0-py3-none-any.whl", hash = "sha256:f2b3366b7cd501a4056858bd39349d5af19742aed2d81660b7998b6341c7eb9c"},
+    {file = "pytest-asyncio-0.21.1.tar.gz", hash = "sha256:40a7eae6dded22c7b604986855ea48400ab15b069ae38116e8c01238e9eeb64d"},
+    {file = "pytest_asyncio-0.21.1-py3-none-any.whl", hash = "sha256:8666c1c8ac02631d7c51ba282e0c69a8a452b211ffedf2599099845da5c5c37b"},
 ]
 pytest-benchmark = [
     {file = "pytest-benchmark-4.0.0.tar.gz", hash = "sha256:fb0785b83efe599a6a956361c0691ae1dbb5318018561af10f3e915caa0048d1"},
@@ -2366,6 +2367,6 @@ xmltodict = [
     {file = "xmltodict-0.13.0.tar.gz", hash = "sha256:341595a488e3e01a85a9d8911d8912fd922ede5fecc4dce437eb4b6c8d037e56"},
 ]
 zipp = [
-    {file = "zipp-3.16.0-py3-none-any.whl", hash = "sha256:5dadc3ad0a1f825fe42ce1bce0f2fc5a13af2e6b2d386af5b0ff295bc0a287d3"},
-    {file = "zipp-3.16.0.tar.gz", hash = "sha256:1876cb065531855bbe83b6c489dcf69ecc28f1068d8e95959fe8bbc77774c941"},
+    {file = "zipp-3.16.1-py3-none-any.whl", hash = "sha256:0b37c326d826d5ca35f2b9685cd750292740774ef16190008b00a0227c256fe0"},
+    {file = "zipp-3.16.1.tar.gz", hash = "sha256:857b158da2cbf427b376da1c24fd11faecbac5a4ac7523c3607f8a01f94c2ec0"},
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,11 +20,13 @@ ddtrace = "1.15.0"
 opentelemetry-sdk = "1.18.0"
 opentelemetry-exporter-otlp-proto-http = "1.18.0"
 opentelemetry-exporter-otlp-proto-grpc = {version = "1.18.0", optional = true}
+structlog-sentry = {version = "^2.0.3", optional = true}
 python-ipware = "^0.9.0"
 pyroscope-io = "^0.8.3"
 
 [tool.poetry.extras]
 grpc = ["opentelemetry-exporter-otlp-proto-grpc"]
+sentry = ["structlog-sentry"]
 
 [tool.poetry.group.dev.dependencies]
 isort = "^5.12.0"
@@ -45,7 +47,6 @@ django = "^4.2.1"
 starlette = "^0.27.0"
 structlog = "^23.1.0"
 celery = "^5.2.7"
-structlog-sentry = "^2.0.3"
 ipython = "^8.14.0"
 
 


### PR DESCRIPTION
Adds two optional kwargs to `configure_structlog`,

`extra_processors` takes a list of extra processors which will be injected just before `format_exc_info`.

`extra_loggers` takes a dict which will be unpacked as part of the `loggers` directive in the core logging config.

This enables apps to add their own logging processors in addition to those defined in `troncos`, and to customize log level and propagation of logger paths.

I think this adds extensibility without introducing undue magic or making assumptions, and that it brings the structlog part of `troncos` from being a 90% solution to a 95% solution. Allowing for extensibility (with clearly defined interfaces) helps keeping `troncos` as a common best practice, rather than requiring apps to do alot of custom implementation to do a little bit of tuning.

The immediate need, which sparked this idea, was this implementation in `interno`: https://github.com/kolonialno/interno/pull/675