### PR TITLE
🐛 bug: Fix ipware import in DJ middleware

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "troncos"
-version = "4.0.2"
+version = "4.0.3b1"
 description = "Collection of Python logging, tracing and profiling tools"
 authors = [
     "Guðmundur Björn Birkisson <gudmundur.birkisson@oda.com>",

--- a/troncos/contrib/django/logging/middleware.py
+++ b/troncos/contrib/django/logging/middleware.py
@@ -4,7 +4,7 @@ from typing import Any
 from asgiref.sync import iscoroutinefunction
 from django.http import HttpRequest, HttpResponse
 from django.utils.decorators import sync_and_async_middleware
-from ipware import IpWare
+from ipware.ipware import IpWare
 
 try:
     from structlog import get_logger


### PR DESCRIPTION
The `ipware` library does not present the `IpWare` class on the top level, but does instead require this class to be imported from `ipware.ipware`.