### PR TITLE
replace dependabot with renovate

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,0 @@
-version: 2
-updates:
-  - package-ecosystem: "pip"
-    directory: "/"
-    schedule:
-      interval: "daily"
-    commit-message:
-      prefix: deps

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -2,7 +2,6 @@
   $schema: "https://docs.renovatebot.com/renovate-schema.json",
   extends: [
     "github>kolonialno/renovate-config",
-    "github>kolonialno/renovate-config:autoMerge",
     "github>kolonialno/renovate-config:groupDevDeps",
     "github>kolonialno/renovate-config:groupPatch",
   ],

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,0 +1,9 @@
+{
+  $schema: "https://docs.renovatebot.com/renovate-schema.json",
+  extends: [
+    "github>kolonialno/renovate-config",
+    "github>kolonialno/renovate-config:autoMerge",
+    "github>kolonialno/renovate-config:groupDevDeps",
+    "github>kolonialno/renovate-config:groupPatch",
+  ],
+}


### PR DESCRIPTION
- Replace Dependabot with Renovate
- Configure Renovate to use shared global presets for Oda

These will automerge all deps up to and including minors.

NODE: A library like Troncos should support large version ranges to make it installable.

Might need some extra packageRules here to enforce this.


What do you think?
