### PR TITLE
Revert "trace_class add tracing for classmethod and staticmethdod (#115)"

### DIFF
--- a/tests/tracing/test_decorators.py
+++ b/tests/tracing/test_decorators.py
@@ -49,11 +49,7 @@ class A:
     "class_attr",
     [
         A.dummy_method,
-        A.adummy_staticmethod,
-        A.dummy_classmethod,
         A.adummy_method,
-        A.adummy_staticmethod,
-        A.adummy_classmethod,
     ],
 )
 def test_trace_class_is_traced(class_attr: Any) -> None:
@@ -66,6 +62,10 @@ def test_trace_class_is_traced(class_attr: Any) -> None:
         A._dummy_underscore,
         A.dummy_property,
         A.adummy_property,
+        A.adummy_staticmethod,
+        A.adummy_classmethod,
+        A.adummy_staticmethod,
+        A.dummy_classmethod,
     ],
 )
 def test_trace_class_is_not_traced(class_attr: Any) -> None:

--- a/troncos/tracing/decorators.py
+++ b/troncos/tracing/decorators.py
@@ -205,10 +205,7 @@ def trace_class(
             if key.startswith("_"):
                 continue
             if not (
-                isinstance(value, FunctionType)
-                or isinstance(value, classmethod)
-                or isinstance(value, staticmethod)
-                or asyncio.iscoroutinefunction(value)
+                isinstance(value, FunctionType) or asyncio.iscoroutinefunction(value)
             ):
                 continue
 


### PR DESCRIPTION
This reverts commit 5a6fc084cd84aa3efb33a4aac3decf30a2439d3e. But leaves some of the tests.

staticmethods and classmethods did not work at all. Same with async. Fixing the issues seemed like enough pain that reverting at least for now.
