### PR TITLE
Remove starlette import from asgi module

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "troncos"
-version = "4.4.0"
+version = "4.4.1"
 description = "Collection of Python logging, tracing and profiling tools"
 authors = [
   "Guðmundur Björn Birkisson <gudmundur.birkisson@oda.com>",

--- a/troncos/contrib/asgi/logging/middleware.py
+++ b/troncos/contrib/asgi/logging/middleware.py
@@ -3,7 +3,6 @@ from typing import Any, Awaitable, Callable, Iterator, Mapping, MutableMapping, 
 
 import ddtrace
 from python_ipware.python_ipware import IpWare
-from starlette.types import ASGIApp
 
 try:
     from structlog import get_logger
@@ -11,6 +10,14 @@ except ImportError:
     raise RuntimeError(
         "Structlog must be installed to use the asgi logging middleware."
     )
+
+Scope = MutableMapping[str, Any]
+Message = MutableMapping[str, Any]
+
+Receive = Callable[[], Awaitable[Message]]
+Send = Callable[[Message], Awaitable[None]]
+
+ASGIApp = Callable[[Scope, Receive, Send], Awaitable[None]]
 
 
 class Headers(Mapping[str, str]):


### PR DESCRIPTION
Starlette is not a dependency of troncos, and asgi apps may not have starlette installed.