### PR TITLE
fix: translate_span: Make assert more specific

### DIFF
--- a/troncos/tracing/_span.py
+++ b/troncos/tracing/_span.py
@@ -137,7 +137,7 @@ def translate_span(
     dd_span: DDSpan, default_resource: Resource, ignore_attrs: set[str]
 ) -> ReadableSpan:
     """Transelate a ddtrace span to an OTEL span."""
-    assert dd_span.duration_ns, "Span not finished."
+    assert dd_span.duration_ns is not None, "Span not finished."
 
     status, events, attributes = _span_status_and_attributes(
         dd_span, ignore_attrs=ignore_attrs


### PR DESCRIPTION
Before this commit, the assert in translate_span would now allow for a duration_ms of `0`. This usually makes sense, but what the assert seems to actually be for, is to check whether duration_ms has been set (that is, somebody has run .finished() on the Span).

This fixes the assert to check that duration_ms is not None, which has the nice side-effect that it allows for Spans to be created+finished in a unittest setting where freezegun.freeze_time() is activated.