### PR TITLE
fix: Handle AttributeError when stopping tracer._writer

### DIFF
--- a/troncos/tracing/__init__.py
+++ b/troncos/tracing/__init__.py
@@ -48,7 +48,7 @@ def configure_tracer(
     # Reconfigure ddtrace to use our new writer.
     try:
         tracer._writer.stop()
-    except ServiceStatusError:
+    except (AttributeError, ServiceStatusError):
         pass
 
     tracer._writer = writer


### PR DESCRIPTION
In ddtrace 3.5, an AttributeError is raised when we run `tracer._writer.stop()`

(At least, we're getting lots of AttributeErrors when running tests in trex: https://github.com/kolonialno/trex/actions/runs/14588876037/job/40919422133?pr=5908)