### PR TITLE
fix: export exception.message for ddtrace 4.x error tags

### DIFF
--- a/troncos/tracing/_span.py
+++ b/troncos/tracing/_span.py
@@ -60,6 +60,14 @@ def _span_kind(dd_span: DDSpan) -> SpanKind:
 
 
 _dd_span_err_attr_mapping = {
+    # Read the keys off ddtrace instead of hardcoding them: ddtrace renamed
+    # "error.msg" to "error.message" in 4.x, which silently dropped the
+    # exception message from exported spans.
+    constants.ERROR_MSG: "exception.message",
+    constants.ERROR_TYPE: "exception.type",
+    constants.ERROR_STACK: "exception.stacktrace",
+    # Keys used by older ddtrace releases, kept so a downgrade does not
+    # reintroduce the same silent data loss.
     "error.msg": "exception.message",
     "error.type": "exception.type",
     "error.stack": "exception.stacktrace",


### PR DESCRIPTION
ddtrace renamed the error message tag from "error.msg" to
"error.message" (constants.ERROR_MSG). The translation table still keyed
off the old name, so every exported span lost its exception message: the
"exception" event carried only type and stacktrace, and the span status
description read "builtins.ValueError: None". The raw "error.message"
tag also leaked through as an ordinary span attribute.

Read the keys off ddtrace.constants instead of hardcoding them, so a
future rename is picked up automatically, and keep the pre-4.x names
mapped so a downgrade does not reintroduce the same silent data loss.
