### PR TITLE
test: verify tracing end to end and guard its cost

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,30 @@ fix-ruff-format: .venv | $(BASE) ; $(info $(M) running ruff format…) @ ## Run 
 test: .venv ; $(info $(M) running tests...) @ ## Run tests
 	$Q $(POETRY) run pytest --cov-report $(TEST_COV_REP) --cov $(PACKAGE) --codeblocks -v
 
+BENCH_ARGS ?= --benchmark-enable --benchmark-only
+BENCH_CMP  ?= 0001
+
+.PHONY: benchmark
+benchmark: .venv ; $(info $(M) running benchmarks...) @ ## Run and save benchmarks
+	$Q $(POETRY) run pytest $(TESTS) ${BENCH_ARGS} --benchmark-autosave
+
+.PHONY: benchmark-cmp
+benchmark-cmp: .venv ; $(info $(M) comparing benchmarks to ${BENCH_CMP}...) @ ## Run benchmarks and compare to a saved run
+	$Q $(POETRY) run pytest $(TESTS) ${BENCH_ARGS} --benchmark-compare=${BENCH_CMP} --benchmark-compare-fail=mean:25%
+
+.PHONY: perf
+perf: .venv ; $(info $(M) running performance gate...) @ ## Run the performance regression gate and print per-arm timings
+	$Q $(POETRY) run pytest $(TESTS)/tracing/test_perf.py -v -s
+
+PROF_DIR  := .prof
+PROF_FILE := ${PROF_DIR}/$(shell date +%H%M%S).prof
+
+.PHONY: profile
+profile: .venv ; $(info $(M) profiling benchmarks...) @ ## Profile the benchmarks and open snakeviz
+	$Q mkdir -p ${PROF_DIR}
+	$Q $(POETRY) run python -m cProfile -o ${PROF_FILE} -m pytest $(TESTS) ${BENCH_ARGS}
+	$Q $(POETRY) run snakeviz ${PROF_FILE}
+
 .PHONY: release
 release: lint test ; $(info $(M) running tests...) @ ## Release to PYPI
 	$Q $(POETRY) publish --build --username=__token__ --password=$(PYPI_TOKEN)

--- a/README.md
+++ b/README.md
@@ -210,6 +210,97 @@ configure_tracer(
 
 Manual instrumentation of your code is described in the [ddtrace docs](https://ddtrace.readthedocs.io/en/stable/basic_usage.html#manual-instrumentation).
 
+### Verifying tracing after a dependency upgrade
+
+Troncos bridges `ddtrace` to OpenTelemetry, which means it depends on internals
+of both libraries. A `ddtrace` or `opentelemetry` bump can therefore break trace
+export without breaking any import.
+
+`tests/tracing/test_e2e.py` exists to catch that. It drives only the public API
+(`configure_tracer`, `Exporter`, the decorators), exports to a local collector,
+and decodes the OTLP protobuf that arrives, asserting on each translated field:
+resource attributes, span name, parent/child linkage, span kind, numeric span
+tags, and exception events. Run it after any dependency upgrade:
+
+```console
+make test
+# or, without the build system:
+pytest tests/tracing/test_e2e.py -v
+```
+
+> **Note**: troncos exports **traces** only; it has no OTLP metrics pipeline.
+> The "metrics" it handles are ddtrace's numeric span tags (`Span.set_metric`),
+> which become typed OTLP span attributes.
+
+### Performance regression tests
+
+`tests/tracing/test_perf.py` measures the same span workload through several
+interchangeable implementations, so their cost can be compared directly:
+
+| Arm | What it measures |
+| --- | --- |
+| `ddtrace` | ddtrace instrumentation exporting msgpack through its own `AgentWriter` |
+| `opentelemetry-http` | the OpenTelemetry SDK over OTLP/HTTP, no ddtrace involved |
+| `troncos-http` | ddtrace instrumentation plus troncos' translation and OTLP/HTTP export |
+| `opentelemetry-grpc` | the OpenTelemetry SDK over OTLP/gRPC |
+| `troncos-grpc` | troncos over OTLP/gRPC, the transport the Grafana agent receives on at 4317 |
+
+The suffix is the OTLP transport, so `troncos-http` and `troncos-grpc` are the
+same implementation over 4318 and 4317. `ddtrace` has no suffix because it
+speaks the Datadog agent protocol rather than OTLP, so it has no transport to
+choose.
+
+Every arm exports to a local endpoint, so the comparison is between encoding
+and translation costs rather than between exporting and not exporting. Each
+gate compares troncos against the arm on the *same* transport, so the ratio
+measures translation cost rather than the difference between HTTP and gRPC.
+
+The `-grpc` arms need the optional `grpc` extra. Without it they drop out of the
+arm list and their gate skips, so the HTTP gates keep working.
+
+Three ratio assertions run as part of the normal test suite and fail if troncos
+becomes disproportionately expensive. Ratios are used rather than absolute
+timings because they stay meaningful on a shared CI runner.
+
+Each arm is timed over 25 rounds of 50 iterations, after 5 warmup rounds. The
+printed table reports the mean and its relative spread. The gates compare
+medians, because roughly 1 round in 60 runs long, usually alongside a
+generation-2 GC pass, and the mean follows that tail while the median does not.
+Timing all five arms takes about 1.2 seconds.
+
+Print the current numbers:
+
+```console
+make perf
+# or, without the build system:
+pytest tests/tracing/test_perf.py -v -s
+```
+
+Record and compare absolute benchmarks (skipped during `make test`):
+
+```console
+make benchmark
+make benchmark-cmp BENCH_CMP=0001
+# or, without the build system:
+pytest tests --benchmark-enable --benchmark-only --benchmark-autosave
+pytest tests --benchmark-enable --benchmark-only --benchmark-compare=0001 \
+  --benchmark-compare-fail=mean:25%
+```
+
+Choose which implementations to measure, and loosen the gates, with environment
+variables:
+
+```console
+TRONCOS_PERF_ARMS=opentelemetry-http,troncos-http make perf
+TRONCOS_PERF_ARMS=opentelemetry-grpc,troncos-grpc make perf
+TRONCOS_PERF_MAX_DDTRACE_RATIO=15 make perf
+TRONCOS_PERF_MAX_OPENTELEMETRY_HTTP_RATIO=3 make perf
+TRONCOS_PERF_MAX_OPENTELEMETRY_GRPC_RATIO=3 make perf
+```
+
+If a gate flakes on a contended runner, raise its limit rather than removing
+the check.
+
 ### Add tracing context to your log
 
 Adding the tracing context to your log makes it easier to find relevant traces in Grafana.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,7 +88,10 @@ filterwarnings = [
   "ignore:Deprecated call to `pkg_resources:DeprecationWarning:",
 ]
 addopts = [
-  "--ignore=perf"
+  # Absolute benchmark timings are noise on a shared runner, so pytest-benchmark
+  # tests are opt-in via `make benchmark`. The ratio-based performance gate in
+  # tests/tracing/test_perf.py is not a benchmark test and still runs here.
+  "--benchmark-skip",
 ]
 env = [
     "DD_TRACE_ENABLED=True",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,255 @@
+"""Shared fixtures for the tracing tests."""
+
+from collections.abc import Iterator
+from typing import Any
+
+import pytest
+from ddtrace.trace import tracer
+
+from troncos.tracing import Exporter, ExporterType, configure_tracer
+
+from tests.tracing.otlp import ExportedSpan, exported_spans
+
+COLLECTOR_PATH = "/v1/traces"
+
+
+@pytest.fixture(autouse=True)
+def restore_tracer_writer() -> Iterator[None]:
+    """Restore the tracer's writer after every test.
+
+    Without this, a test that points the process-wide tracer at a local
+    collector leaves it aimed at a stopped server, and the next flush blocks on
+    a dead socket. `_span_aggregator` is the only handle ddtrace offers.
+    """
+    aggregator = tracer._span_aggregator
+    original_writer = aggregator.writer
+
+    yield
+
+    if aggregator.writer is not original_writer:
+        try:
+            aggregator.writer.stop()
+        except Exception:
+            pass
+        aggregator.writer = original_writer
+        tracer._recreate()
+
+
+def _stop_installed_writer() -> None:
+    """Shut the tracer's current writer down, ignoring an already-stopped one.
+
+    Called before a collector goes away. On OTLP/gRPC the exporter holds a
+    channel that reconnects on its own, so a writer outliving its server keeps
+    retrying and logging into whichever test runs next; on HTTP a dead socket
+    just fails quietly. Order matters, so the collector fixtures do this
+    themselves rather than leaving it to `restore_tracer_writer`, which
+    finalises after them.
+    """
+    try:
+        tracer._span_aggregator.writer.stop()
+    except Exception:
+        pass
+
+
+class TraceCollector:
+    """Drives troncos' public API and reads back what reached the collector.
+
+    Subclassed per transport. Projects point troncos at an OTLP endpoint over
+    either HTTP (4318) or gRPC (4317) — Alloy's receiver commonly offers both —
+    and a translation or export bug that only shows on one of them is invisible
+    to a suite that exercises the other, so the payload assertions run against
+    this interface rather than against one transport's plumbing.
+    """
+
+    transport: str
+
+    def __init__(self) -> None:
+        self._configured = False
+
+    # --- implemented per transport -------------------------------------
+
+    def exporter(self, *, headers: dict[str, str] | None = None) -> Exporter:
+        raise NotImplementedError
+
+    def _received_spans(self) -> list[ExportedSpan]:
+        raise NotImplementedError
+
+    def requests(self) -> list[Any]:
+        raise NotImplementedError
+
+    # --- shared --------------------------------------------------------
+
+    def _configure(
+        self,
+        *,
+        service_name: str,
+        exporter: Exporter,
+        resource_attributes: dict[str, Any] | None,
+        enabled: bool,
+    ) -> None:
+        assert tracer.current_span() is None, "a previous test leaked an active span"
+
+        configure_tracer(
+            service_name=service_name,
+            exporter=exporter,
+            resource_attributes=resource_attributes,
+            enabled=enabled,
+        )
+        self._configured = True
+
+    def configure(
+        self,
+        *,
+        service_name: str,
+        resource_attributes: dict[str, Any] | None = None,
+        enabled: bool = True,
+        headers: dict[str, str] | None = None,
+    ) -> None:
+        self._configure(
+            service_name=service_name,
+            exporter=self.exporter(headers=headers),
+            resource_attributes=resource_attributes,
+            enabled=enabled,
+        )
+
+    def collect(self) -> list[ExportedSpan]:
+        assert self._configured, "call configure() before collect()"
+        tracer.flush()  # type: ignore[no-untyped-call]
+        return self._received_spans()
+
+
+class HttpTraceCollector(TraceCollector):
+    """OTLP over HTTP/protobuf, the default troncos exports to (port 4318)."""
+
+    transport = "http"
+
+    def __init__(self, httpserver: Any) -> None:
+        super().__init__()
+        self._httpserver = httpserver
+
+    @property
+    def host(self) -> str:
+        return str(self._httpserver.host)
+
+    @property
+    def port(self) -> str:
+        return str(self._httpserver.port)
+
+    def exporter(
+        self,
+        *,
+        path: str = COLLECTOR_PATH,
+        headers: dict[str, str] | None = None,
+    ) -> Exporter:
+        return Exporter(
+            host=self.host,
+            port=self.port,
+            path=path,
+            exporter_type=ExporterType.HTTP,
+            headers=headers,
+        )
+
+    def configure(
+        self,
+        *,
+        service_name: str,
+        resource_attributes: dict[str, Any] | None = None,
+        enabled: bool = True,
+        path: str = COLLECTOR_PATH,
+        headers: dict[str, str] | None = None,
+    ) -> None:
+        self._configure(
+            service_name=service_name,
+            exporter=self.exporter(path=path, headers=headers),
+            resource_attributes=resource_attributes,
+            enabled=enabled,
+        )
+
+    def _received_spans(self, *, path: str = COLLECTOR_PATH) -> list[ExportedSpan]:
+        return exported_spans(self._httpserver, path)
+
+    def collect(self, *, path: str = COLLECTOR_PATH) -> list[ExportedSpan]:
+        assert self._configured, "call configure() before collect()"
+        tracer.flush()  # type: ignore[no-untyped-call]
+        return self._received_spans(path=path)
+
+    def requests(self, *, path: str = COLLECTOR_PATH) -> list[Any]:
+        return [request for request, _ in self._httpserver.log if request.path == path]
+
+
+class GrpcTraceCollector(TraceCollector):
+    """OTLP over gRPC, the transport Alloy's receiver listens on at 4317."""
+
+    transport = "grpc"
+
+    def __init__(self, server: Any) -> None:
+        super().__init__()
+        self._server = server
+
+    @property
+    def host(self) -> str:
+        return str(self._server.host)
+
+    @property
+    def port(self) -> str:
+        return str(self._server.port)
+
+    def exporter(self, *, headers: dict[str, str] | None = None) -> Exporter:
+        return Exporter(
+            host=self.host,
+            port=self.port,
+            # Both are what troncos derives from port 4317 on its own, spelled
+            # out because the test server is on an ephemeral port.
+            path="/",
+            exporter_type=ExporterType.GRPC,
+            headers=headers,
+        )
+
+    def _received_spans(self) -> list[ExportedSpan]:
+        return list(self._server.exported_spans())
+
+    def requests(self) -> list[Any]:
+        return list(self._server.requests)
+
+
+@pytest.fixture
+def traces(httpserver: Any) -> Iterator[HttpTraceCollector]:
+    httpserver.expect_request(COLLECTOR_PATH).respond_with_data("OK")
+    collector = HttpTraceCollector(httpserver)
+    try:
+        yield collector
+    finally:
+        _stop_installed_writer()
+
+
+@pytest.fixture
+def grpc_traces() -> Iterator[GrpcTraceCollector]:
+    pytest.importorskip(
+        "opentelemetry.exporter.otlp.proto.grpc.trace_exporter",
+        reason="needs the 'grpc' extra",
+    )
+    pytest.importorskip("grpc", reason="needs grpcio to run a local gRPC collector")
+
+    from tests.tracing.otlp_grpc import GrpcSpanCollector
+
+    server = GrpcSpanCollector().start()
+    try:
+        yield GrpcTraceCollector(server)
+    finally:
+        _stop_installed_writer()
+        server.stop()
+
+
+@pytest.fixture(params=["http", "grpc"])
+def any_traces(request: pytest.FixtureRequest) -> TraceCollector:
+    """The same test, run over both OTLP transports.
+
+    Used by the tests that assert on payload content, which must not depend on
+    how the payload got there. Transport-specific plumbing (the HTTP path,
+    content-type, gRPC call metadata) keeps its own tests.
+    """
+    collector = request.getfixturevalue(
+        {"http": "traces", "grpc": "grpc_traces"}[str(request.param)]
+    )
+    assert isinstance(collector, TraceCollector)
+    return collector

--- a/tests/tracing/otlp.py
+++ b/tests/tracing/otlp.py
@@ -1,0 +1,162 @@
+"""Helpers for decoding the OTLP payloads that troncos exports.
+
+Decoding the protobuf rather than matching raw bytes means a failure names the
+attribute that went missing, which is what makes these tests useful after a
+ddtrace or opentelemetry bump changes the translation.
+"""
+
+import gzip
+from dataclasses import dataclass, field
+from typing import Any
+
+from opentelemetry.proto.collector.trace.v1.trace_service_pb2 import (
+    ExportTraceServiceRequest,
+)
+from opentelemetry.proto.common.v1.common_pb2 import AnyValue
+from opentelemetry.proto.trace.v1.trace_pb2 import Span as PBSpan
+from opentelemetry.proto.trace.v1.trace_pb2 import Status as PBStatus
+from pytest_httpserver import HTTPServer
+
+# The all-zero span id protobuf uses to mean "no parent".
+_NO_PARENT = b""
+
+
+@dataclass(frozen=True)
+class ExportedEvent:
+    name: str
+    attributes: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class ExportedSpan:
+    """A span as it arrived at the collector, with its resource flattened in."""
+
+    name: str
+    kind: str
+    trace_id: bytes
+    span_id: bytes
+    parent_span_id: bytes
+    attributes: dict[str, Any]
+    events: list[ExportedEvent]
+    status_code: str
+    status_message: str
+    resource_attributes: dict[str, Any] = field(default_factory=dict)
+    start_time_unix_nano: int = 0
+    end_time_unix_nano: int = 0
+
+    @property
+    def has_parent(self) -> bool:
+        return self.parent_span_id != _NO_PARENT
+
+    @property
+    def service_name(self) -> str:
+        value = self.resource_attributes.get("service.name")
+        assert isinstance(value, str), f"span {self.name!r} has no service.name"
+        return value
+
+    @property
+    def exception_events(self) -> list[ExportedEvent]:
+        return [event for event in self.events if event.name == "exception"]
+
+
+def _decode_any_value(value: AnyValue) -> Any:
+    which = value.WhichOneof("value")
+    if which is None:
+        return None
+    if which == "array_value":
+        return [_decode_any_value(item) for item in value.array_value.values]
+    if which == "kvlist_value":
+        return _decode_attributes(value.kvlist_value.values)
+    return getattr(value, which)
+
+
+def _decode_attributes(attributes: Any) -> dict[str, Any]:
+    return {kv.key: _decode_any_value(kv.value) for kv in attributes}
+
+
+def _decode_span(span: PBSpan, resource_attributes: dict[str, Any]) -> ExportedSpan:
+    return ExportedSpan(
+        name=span.name,
+        kind=str(PBSpan.SpanKind.Name(span.kind)),
+        trace_id=span.trace_id,
+        span_id=span.span_id,
+        parent_span_id=span.parent_span_id,
+        attributes=_decode_attributes(span.attributes),
+        events=[
+            ExportedEvent(
+                name=event.name, attributes=_decode_attributes(event.attributes)
+            )
+            for event in span.events
+        ],
+        status_code=str(PBStatus.StatusCode.Name(span.status.code)),
+        status_message=span.status.message,
+        resource_attributes=resource_attributes,
+        start_time_unix_nano=span.start_time_unix_nano,
+        end_time_unix_nano=span.end_time_unix_nano,
+    )
+
+
+def spans_from_message(message: ExportTraceServiceRequest) -> list[ExportedSpan]:
+    """Flatten an export request into spans, resource attributes folded in.
+
+    Shared by both transports: OTLP/HTTP hands us bytes to parse, OTLP/gRPC
+    hands the servicer an already-parsed message, and both must decode to the
+    same ExportedSpan so the payload assertions can be transport-agnostic.
+    """
+    spans: list[ExportedSpan] = []
+    for resource_spans in message.resource_spans:
+        resource_attributes = _decode_attributes(resource_spans.resource.attributes)
+        for scope_spans in resource_spans.scope_spans:
+            for span in scope_spans.spans:
+                spans.append(_decode_span(span, resource_attributes))
+    return spans
+
+
+def decode_request_body(
+    body: bytes, content_encoding: str | None
+) -> list[ExportedSpan]:
+    if content_encoding == "gzip":
+        body = gzip.decompress(body)
+
+    message = ExportTraceServiceRequest()
+    message.ParseFromString(body)
+
+    return spans_from_message(message)
+
+
+def exported_spans(httpserver: HTTPServer, path: str) -> list[ExportedSpan]:
+    """Decode every span posted to `path`.
+
+    Asserts each request was accepted, so a rejected payload surfaces as a
+    failure rather than an empty result.
+    """
+    spans: list[ExportedSpan] = []
+    for request, response in httpserver.log:
+        if request.path != path:
+            continue
+        assert response.status_code == 200, (
+            f"collector rejected an export with {response.status_code}"
+        )
+        spans.extend(
+            decode_request_body(request.data, request.headers.get("content-encoding"))
+        )
+    return spans
+
+
+def span_named(spans: list[ExportedSpan], name: str) -> ExportedSpan:
+    matches = [span for span in spans if span.name == name]
+    assert len(matches) == 1, (
+        f"expected exactly 1 span named {name!r}, "
+        f"got {len(matches)} (exported: {sorted(s.name for s in spans)})"
+    )
+    return matches[0]
+
+
+__all__ = [
+    "ExportedEvent",
+    "ExportedSpan",
+    "decode_request_body",
+    "exported_spans",
+    "span_named",
+    "spans_from_message",
+]

--- a/tests/tracing/otlp_grpc.py
+++ b/tests/tracing/otlp_grpc.py
@@ -1,0 +1,107 @@
+"""A real in-process OTLP/gRPC collector.
+
+Grafana Alloy's (and the OpenTelemetry Collector's) OTLP receiver listens on
+gRPC at 4317 by default, so that is the transport a large share of deployments
+actually use. Constructing the gRPC exporter proves the import path still
+exists; only a server on the other end proves the payload arrives, which is
+what this collector is for.
+
+Deliberately not a mock: the gRPC stack rejects malformed call metadata and
+oversized messages on its own, so failures here are the ones a real collector
+would produce.
+"""
+
+import threading
+from collections.abc import Iterator
+from concurrent import futures
+from contextlib import contextmanager
+from dataclasses import dataclass
+from typing import Any
+
+import grpc
+from opentelemetry.proto.collector.trace.v1 import trace_service_pb2_grpc
+from opentelemetry.proto.collector.trace.v1.trace_service_pb2 import (
+    ExportTraceServiceRequest,
+    ExportTraceServiceResponse,
+)
+
+from tests.tracing.otlp import ExportedSpan, spans_from_message
+
+
+@dataclass(frozen=True)
+class GrpcExportRequest:
+    """One Export call, with the call metadata gRPC delivered alongside it."""
+
+    message: ExportTraceServiceRequest
+    metadata: dict[str, str]
+
+    @property
+    def headers(self) -> dict[str, str]:
+        """Alias so assertions can read the same as on the HTTP transport."""
+        return self.metadata
+
+
+class _TraceServicer(trace_service_pb2_grpc.TraceServiceServicer):
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self.requests: list[GrpcExportRequest] = []
+
+    def Export(  # the name comes from the OTLP service definition
+        self, request: ExportTraceServiceRequest, context: Any
+    ) -> ExportTraceServiceResponse:
+        metadata = dict(context.invocation_metadata())
+        with self._lock:
+            self.requests.append(GrpcExportRequest(message=request, metadata=metadata))
+        return ExportTraceServiceResponse()
+
+
+class GrpcSpanCollector:
+    """OTLP/gRPC endpoint on an ephemeral localhost port."""
+
+    def __init__(self) -> None:
+        self._servicer = _TraceServicer()
+        self._server = grpc.server(futures.ThreadPoolExecutor(max_workers=4))
+        trace_service_pb2_grpc.add_TraceServiceServicer_to_server(  # type: ignore[no-untyped-call]
+            self._servicer, self._server
+        )
+        self._port = self._server.add_insecure_port("127.0.0.1:0")
+
+    def start(self) -> "GrpcSpanCollector":
+        self._server.start()
+        return self
+
+    def stop(self) -> None:
+        # grace=None: no in-flight call should outlive a test, and waiting for
+        # one would hide an exporter that never finished.
+        self._server.stop(None)
+
+    @property
+    def host(self) -> str:
+        return "127.0.0.1"
+
+    @property
+    def port(self) -> str:
+        return str(self._port)
+
+    @property
+    def requests(self) -> list[GrpcExportRequest]:
+        with self._servicer._lock:
+            return list(self._servicer.requests)
+
+    def exported_spans(self) -> list[ExportedSpan]:
+        spans: list[ExportedSpan] = []
+        for request in self.requests:
+            spans.extend(spans_from_message(request.message))
+        return spans
+
+
+@contextmanager
+def grpc_collector() -> Iterator[GrpcSpanCollector]:
+    collector = GrpcSpanCollector().start()
+    try:
+        yield collector
+    finally:
+        collector.stop()
+
+
+__all__ = ["GrpcExportRequest", "GrpcSpanCollector", "grpc_collector"]

--- a/tests/tracing/perf.py
+++ b/tests/tracing/perf.py
@@ -1,0 +1,445 @@
+"""Benchmark harness comparing troncos against raw ddtrace and raw OpenTelemetry.
+
+Every arm runs the same span workload and exports it to a local endpoint, so
+their timings are comparable: ddtrace ships msgpack to a fake Datadog agent, the
+others ship OTLP protobuf to a fake collector.
+
+The flush is part of the measured work on purpose. Troncos translates spans in
+OTELWriter.write(), which ddtrace only calls on flush, so a benchmark that
+creates spans without flushing reports the bridge as free.
+
+Arm names carry the OTLP transport as a suffix, so `troncos-http` and
+`troncos-grpc` are the same implementation over HTTP (4318) and gRPC (4317).
+Each `-grpc` arm is compared against the `-grpc` arm of the other
+implementation rather than against an HTTP one, so the ratio measures troncos'
+translation cost instead of the difference between the two transports. The
+`-grpc` arms need the optional `grpc` extra and drop out of the default arm
+list when it is missing.
+
+`ddtrace` has no suffix: it speaks the Datadog agent protocol rather than OTLP,
+so it has no transport to choose.
+"""
+
+import json
+import os
+import threading
+from collections.abc import Callable
+from concurrent import futures
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Any, Protocol
+
+from ddtrace.trace import tracer
+
+from troncos.tracing import Exporter, ExporterType, create_trace_writer
+
+try:
+    import grpc
+
+    # The arms need the exporter from the optional 'grpc' extra, and the local
+    # collector needs grpcio, which that package depends on. Probing the
+    # exporter therefore covers both; probing only grpcio would not, since it
+    # arrives as a dev dependency on its own.
+    from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import (  # noqa: F401
+        OTLPSpanExporter as _GrpcSpanExporter,
+    )
+    from opentelemetry.proto.collector.trace.v1 import trace_service_pb2_grpc
+    from opentelemetry.proto.collector.trace.v1.trace_service_pb2 import (
+        ExportTraceServiceResponse,
+    )
+
+    GRPC_AVAILABLE = True
+except ImportError:  # pragma: no cover - depends on the installed extras
+    GRPC_AVAILABLE = False
+
+SERVICE_NAME = "perf-service"
+RESOURCE_ATTRIBUTES = {"app": "perf", "component": "benchmark"}
+
+OTLP_PATH = "/v1/traces"
+
+CHILDREN_PER_ROOT = 8
+
+HTTP_ARMS = ("opentelemetry-http", "troncos-http")
+GRPC_ARMS = ("opentelemetry-grpc", "troncos-grpc")
+
+ALL_ARMS = ("ddtrace", *HTTP_ARMS, *GRPC_ARMS)
+
+_AGENT_RESPONSE = json.dumps({"rate_by_service": {}}).encode()
+
+
+def selected_arms() -> tuple[str, ...]:
+    """Arms to benchmark, from TRONCOS_PERF_ARMS (comma separated)."""
+    raw = os.environ.get("TRONCOS_PERF_ARMS")
+    if not raw:
+        # Without the 'grpc' extra the gRPC arms cannot run. Dropping them from
+        # the default list keeps the HTTP gates working and lets the gRPC gate
+        # skip itself, instead of failing a run that never asked for gRPC.
+        return tuple(
+            name for name in ALL_ARMS if GRPC_AVAILABLE or name not in GRPC_ARMS
+        )
+
+    names = tuple(name.strip() for name in raw.split(",") if name.strip())
+    unknown = [name for name in names if name not in ALL_ARMS]
+    if unknown:
+        raise ValueError(
+            f"unknown arm(s) {unknown} in TRONCOS_PERF_ARMS; "
+            f"valid arms are {list(ALL_ARMS)}"
+        )
+    if not GRPC_AVAILABLE:
+        unavailable = [name for name in names if name in GRPC_ARMS]
+        if unavailable:
+            raise ValueError(
+                f"arm(s) {unavailable} need the optional 'grpc' extra installed"
+            )
+    return names
+
+
+class _CollectorHandler(BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+
+    def _handle(self) -> None:
+        length = int(self.headers.get("Content-Length") or 0)
+        if length:
+            self.rfile.read(length)
+
+        self.server.record_request()  # type: ignore[attr-defined]
+
+        # Only the Datadog agent protocol expects a JSON body back; sending one
+        # on the OTLP path makes the OTLP exporter log about it.
+        body = b"" if self.path == OTLP_PATH else _AGENT_RESPONSE
+        self.send_response(200)
+        if body:
+            self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        if body:
+            self.wfile.write(body)
+
+    # ddtrace PUTs to /v0.5/traces, the OTLP exporter POSTs.
+    do_POST = _handle
+    do_PUT = _handle
+
+    def log_message(self, format: str, *args: Any) -> None:
+        """Silence per-request logging; it would dominate the benchmark."""
+
+
+class _CountingHTTPServer(ThreadingHTTPServer):
+    daemon_threads = True
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self._lock = threading.Lock()
+        self.request_count = 0
+
+    def record_request(self) -> None:
+        with self._lock:
+            self.request_count += 1
+
+
+if GRPC_AVAILABLE:
+
+    class _CountingTraceServicer(trace_service_pb2_grpc.TraceServiceServicer):
+        """Counts exports and drops the payload; decoding it would be measured."""
+
+        def __init__(self) -> None:
+            self._lock = threading.Lock()
+            self.request_count = 0
+
+        def Export(  # the name comes from the OTLP service definition
+            self, request: Any, context: Any
+        ) -> "ExportTraceServiceResponse":
+            with self._lock:
+                self.request_count += 1
+            return ExportTraceServiceResponse()
+
+
+class NullCollector:
+    """Local endpoint accepting OTLP over HTTP and gRPC, plus Datadog agent exports.
+
+    Deliberately not pytest-httpserver: its unbounded request log and
+    per-request bookkeeping show up in the timings.
+
+    Both transports are served at once so an arm can pick the one it needs
+    without the fixture having to know which arms were selected.
+    """
+
+    def __init__(self) -> None:
+        self._server = _CountingHTTPServer(("127.0.0.1", 0), _CollectorHandler)
+        self._thread = threading.Thread(target=self._server.serve_forever, daemon=True)
+
+        self._grpc_server: Any = None
+        self._grpc_servicer: Any = None
+        self._grpc_port = 0
+        if GRPC_AVAILABLE:
+            self._grpc_servicer = _CountingTraceServicer()
+            # No compression and no interceptors, so this stays as close to raw
+            # transport cost as the gRPC stack allows.
+            self._grpc_server = grpc.server(futures.ThreadPoolExecutor(max_workers=4))
+            trace_service_pb2_grpc.add_TraceServiceServicer_to_server(  # type: ignore[no-untyped-call]
+                self._grpc_servicer, self._grpc_server
+            )
+            self._grpc_port = self._grpc_server.add_insecure_port("127.0.0.1:0")
+
+    def start(self) -> "NullCollector":
+        self._thread.start()
+        if self._grpc_server is not None:
+            self._grpc_server.start()
+        return self
+
+    def stop(self) -> None:
+        if self._grpc_server is not None:
+            self._grpc_server.stop(None)
+        self._server.shutdown()
+        self._server.server_close()
+        self._thread.join(timeout=5)
+
+    @property
+    def host(self) -> str:
+        return str(self._server.server_address[0])
+
+    @property
+    def port(self) -> str:
+        return str(self._server.server_address[1])
+
+    @property
+    def grpc_port(self) -> str:
+        assert self._grpc_port, "the gRPC collector needs the 'grpc' extra"
+        return str(self._grpc_port)
+
+    @property
+    def request_count(self) -> int:
+        """Exports received over either transport.
+
+        Summed rather than kept per transport because the only caller asks
+        whether the arm it just timed reached the collector at all.
+        """
+        count = int(self._server.request_count)
+        if self._grpc_servicer is not None:
+            count += int(self._grpc_servicer.request_count)
+        return count
+
+    @property
+    def agent_url(self) -> str:
+        return f"http://{self.host}:{self.port}"
+
+    def exporter(self) -> Exporter:
+        return Exporter(
+            host=self.host,
+            port=self.port,
+            path=OTLP_PATH,
+            exporter_type=ExporterType.HTTP,
+        )
+
+    def grpc_exporter(self) -> Exporter:
+        return Exporter(
+            host=self.host,
+            port=self.grpc_port,
+            path="/",
+            exporter_type=ExporterType.GRPC,
+        )
+
+
+class Arm(Protocol):
+    """One tracing implementation, driven through a common interface."""
+
+    name: str
+
+    def setup(self, collector: NullCollector) -> None: ...
+
+    def run(self, iterations: int) -> None: ...
+
+    def teardown(self) -> None: ...
+
+
+class _DDTraceArmBase:
+    """Shared ddtrace workload and writer swapping."""
+
+    name = "ddtrace"
+
+    def __init__(self) -> None:
+        self._original_writer: Any = None
+        self._writers: list[Any] = []
+
+    def _install_writer(self, writer: Any) -> None:
+        aggregator = tracer._span_aggregator
+        self._original_writer = aggregator.writer
+        aggregator.writer = writer
+        tracer._recreate()
+        # _recreate() swaps in writer.recreate(), so the live writer is not the
+        # one built above; both need stopping. On gRPC the orphan holds a
+        # channel that keeps reconnecting to a collector later tests have
+        # already shut down.
+        self._writers = [writer, aggregator.writer]
+
+    def run(self, iterations: int) -> None:
+        for iteration in range(iterations):
+            with tracer.trace("perf.root", service=SERVICE_NAME) as root:
+                root.set_tag("workload", "perf")
+                root.set_tag("http.method", "GET")
+                root.set_metric("iteration", iteration)
+                for index in range(CHILDREN_PER_ROOT):
+                    with tracer.trace("perf.child", service=SERVICE_NAME) as child:
+                        child.set_tag("child.name", f"child-{index}")
+                        child.set_metric("child.index", index)
+        tracer.flush()  # type: ignore[no-untyped-call]
+
+    def teardown(self) -> None:
+        if self._original_writer is None:
+            return
+        aggregator = tracer._span_aggregator
+        for writer in self._writers:
+            try:
+                writer.stop()
+            except Exception:
+                pass
+        self._writers = []
+        aggregator.writer = self._original_writer
+        tracer._recreate()
+        self._original_writer = None
+
+
+class DDTraceArm(_DDTraceArmBase):
+    """ddtrace instrumentation exporting through its own AgentWriter."""
+
+    name = "ddtrace"
+
+    def setup(self, collector: NullCollector) -> None:
+        from ddtrace.internal.writer import AgentWriter
+
+        # report_metrics=False because troncos' writer reports no statsd
+        # metrics either; leaving it on would charge this arm for work the
+        # other two never do.
+        self._install_writer(
+            AgentWriter(intake_url=collector.agent_url, report_metrics=False)
+        )
+
+
+class TroncosHttpArm(_DDTraceArmBase):
+    """ddtrace instrumentation translated and exported by troncos over HTTP."""
+
+    name = "troncos-http"
+
+    def setup(self, collector: NullCollector) -> None:
+        self._install_writer(
+            create_trace_writer(
+                enabled=True,
+                service_name=SERVICE_NAME,
+                exporter=collector.exporter(),
+                resource_attributes=RESOURCE_ATTRIBUTES,
+            )
+        )
+
+
+class TroncosGrpcArm(_DDTraceArmBase):
+    """The same as TroncosHttpArm, exporting over OTLP/gRPC."""
+
+    name = "troncos-grpc"
+
+    def setup(self, collector: NullCollector) -> None:
+        self._install_writer(
+            create_trace_writer(
+                enabled=True,
+                service_name=SERVICE_NAME,
+                exporter=collector.grpc_exporter(),
+                resource_attributes=RESOURCE_ATTRIBUTES,
+            )
+        )
+
+
+class _OpenTelemetryArmBase:
+    """Shared OpenTelemetry SDK workload, with no ddtrace involved.
+
+    Subclassed per transport; the subclass supplies the span exporter.
+    """
+
+    name: str
+
+    def __init__(self) -> None:
+        self._provider: Any = None
+        self._tracer: Any = None
+
+    def _span_exporter(self, collector: NullCollector) -> Any:
+        raise NotImplementedError
+
+    def setup(self, collector: NullCollector) -> None:
+        from opentelemetry.sdk.resources import Resource
+        from opentelemetry.sdk.trace import TracerProvider
+        from opentelemetry.sdk.trace.export import BatchSpanProcessor
+
+        self._provider = TracerProvider(
+            resource=Resource.create(
+                {"service.name": SERVICE_NAME, **RESOURCE_ATTRIBUTES}
+            )
+        )
+        self._provider.add_span_processor(
+            BatchSpanProcessor(self._span_exporter(collector))
+        )
+        # Not registered as the global provider: that is process-wide state a
+        # test should not leave behind.
+        self._tracer = self._provider.get_tracer("troncos.perf")
+
+    def run(self, iterations: int) -> None:
+        for iteration in range(iterations):
+            with self._tracer.start_as_current_span("perf.root") as root:
+                root.set_attribute("workload", "perf")
+                root.set_attribute("http.method", "GET")
+                root.set_attribute("iteration", iteration)
+                for index in range(CHILDREN_PER_ROOT):
+                    with self._tracer.start_as_current_span("perf.child") as child:
+                        child.set_attribute("child.name", f"child-{index}")
+                        child.set_attribute("child.index", index)
+        self._provider.force_flush()
+
+    def teardown(self) -> None:
+        if self._provider is not None:
+            self._provider.shutdown()
+            self._provider = None
+            self._tracer = None
+
+
+class OpenTelemetryHttpArm(_OpenTelemetryArmBase):
+    """The OpenTelemetry SDK over HTTP: the baseline for the troncos HTTP arm."""
+
+    name = "opentelemetry-http"
+
+    def _span_exporter(self, collector: NullCollector) -> Any:
+        from opentelemetry.exporter.otlp.proto.http.trace_exporter import (
+            OTLPSpanExporter,
+        )
+
+        return OTLPSpanExporter(endpoint=collector.exporter().endpoint)
+
+
+class OpenTelemetryGrpcArm(_OpenTelemetryArmBase):
+    """The OpenTelemetry SDK over gRPC: the baseline for the troncos gRPC arm."""
+
+    name = "opentelemetry-grpc"
+
+    def _span_exporter(self, collector: NullCollector) -> Any:
+        from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import (
+            OTLPSpanExporter,
+        )
+
+        return OTLPSpanExporter(endpoint=collector.grpc_exporter().endpoint)
+
+
+_ARM_FACTORIES: dict[str, Callable[[], Arm]] = {
+    "ddtrace": DDTraceArm,
+    "opentelemetry-http": OpenTelemetryHttpArm,
+    "opentelemetry-grpc": OpenTelemetryGrpcArm,
+    "troncos-http": TroncosHttpArm,
+    "troncos-grpc": TroncosGrpcArm,
+}
+
+
+def build_arm(name: str) -> Arm:
+    try:
+        factory = _ARM_FACTORIES[name]
+    except KeyError:
+        raise ValueError(
+            f"unknown arm {name!r}; valid arms are {list(ALL_ARMS)}"
+        ) from None
+    return factory()
+
+
+def spans_per_iteration() -> int:
+    return CHILDREN_PER_ROOT + 1

--- a/tests/tracing/test_e2e.py
+++ b/tests/tracing/test_e2e.py
@@ -1,0 +1,713 @@
+"""End-to-end verification of the troncos trace pipeline.
+
+Black box on purpose: these tests touch only troncos' public API and ddtrace's
+public tracer, then assert on the decoded OTLP payload that reached a local
+collector. One configure_tracer plus tracer.trace() call exercises every
+third-party internal troncos depends on (Tracer._span_aggregator,
+Tracer._recreate, the TraceWriter interface, Span._meta/._metrics/._parent, and
+the OTel SDK internals behind ReadableSpan), so a dependency bump that moves any
+of them fails here.
+
+Troncos exports traces only; it has no OTLP metrics pipeline. The "metrics" it
+handles are ddtrace's numeric span tags, covered by
+test_numeric_metrics_become_numeric_attributes.
+"""
+
+import time
+from pathlib import Path
+from typing import Any
+
+import pytest
+from ddtrace.ext import SpanKind as DDSpanKind
+from ddtrace.trace import tracer
+
+from troncos.tracing import Exporter, ExporterType
+from troncos.tracing.decorators import (
+    trace_block,
+    trace_class,
+    trace_function,
+    trace_ignore,
+)
+
+from tests.conftest import (
+    COLLECTOR_PATH,
+    GrpcTraceCollector,
+    HttpTraceCollector,
+    TraceCollector,
+)
+from tests.tracing.otlp import span_named
+
+
+def test_service_name_becomes_resource_service_name(any_traces: TraceCollector) -> None:
+    any_traces.configure(service_name="checkout-api")
+
+    with tracer.trace("handle-request", service="checkout-api"):
+        pass
+
+    span = span_named(any_traces.collect(), "handle-request")
+    assert span.service_name == "checkout-api"
+
+
+def test_resource_attributes_are_exported(any_traces: TraceCollector) -> None:
+    any_traces.configure(
+        service_name="checkout-api",
+        resource_attributes={
+            "app": "checkout",
+            "component": "api",
+            "role": "web",
+            "tenant": "no",
+        },
+    )
+
+    with tracer.trace("handle-request", service="checkout-api"):
+        pass
+
+    span = span_named(any_traces.collect(), "handle-request")
+    assert span.resource_attributes["app"] == "checkout"
+    assert span.resource_attributes["component"] == "api"
+    assert span.resource_attributes["role"] == "web"
+    assert span.resource_attributes["tenant"] == "no"
+
+
+def test_per_span_service_gets_its_own_resource(any_traces: TraceCollector) -> None:
+    """A span tagged with a different service must not inherit the default one."""
+    any_traces.configure(
+        service_name="checkout-api", resource_attributes={"app": "checkout"}
+    )
+
+    with tracer.trace("handle-request", service="checkout-api"):
+        with tracer.trace("query", service="checkout-db"):
+            pass
+
+    spans = any_traces.collect()
+    assert span_named(spans, "handle-request").service_name == "checkout-api"
+
+    db_span = span_named(spans, "query")
+    assert db_span.service_name == "checkout-db"
+    # Non-service resource attributes are still carried over.
+    assert db_span.resource_attributes["app"] == "checkout"
+
+
+def test_resource_attributes_are_not_duplicated_as_span_attributes(
+    traces: TraceCollector,
+) -> None:
+    traces.configure(
+        service_name="checkout-api", resource_attributes={"app": "checkout"}
+    )
+
+    with tracer.trace("handle-request", service="checkout-api"):
+        pass
+
+    span = span_named(traces.collect(), "handle-request")
+    assert "app" not in span.attributes
+    assert "service.name" not in span.attributes
+
+
+def test_span_name_and_resource_are_exported(traces: TraceCollector) -> None:
+    traces.configure(service_name="checkout-api")
+
+    with tracer.trace("http.request", resource="GET /orders"):
+        pass
+
+    span = span_named(traces.collect(), "http.request")
+    assert span.name == "http.request"
+    # ddtrace's "resource" has no OTLP equivalent, so troncos exports it as an
+    # attribute. Losing it would make spans unsearchable in Tempo.
+    assert span.attributes["resource"] == "GET /orders"
+
+
+def test_span_timing_is_exported(traces: TraceCollector) -> None:
+    traces.configure(service_name="checkout-api")
+
+    before = time.time_ns()
+    with tracer.trace("slow-thing"):
+        time.sleep(0.01)
+    after = time.time_ns()
+
+    span = span_named(traces.collect(), "slow-thing")
+    assert span.start_time_unix_nano >= before
+    assert span.end_time_unix_nano <= after
+    assert span.end_time_unix_nano > span.start_time_unix_nano
+    # Nanosecond units, not microseconds or seconds.
+    assert span.end_time_unix_nano - span.start_time_unix_nano >= 10_000_000
+
+
+def test_parent_child_linkage_is_preserved(any_traces: TraceCollector) -> None:
+    any_traces.configure(service_name="checkout-api")
+
+    with tracer.trace("root"):
+        with tracer.trace("child"):
+            with tracer.trace("grandchild"):
+                pass
+
+    spans = any_traces.collect()
+    root = span_named(spans, "root")
+    child = span_named(spans, "child")
+    grandchild = span_named(spans, "grandchild")
+
+    assert not root.has_parent, "root span should have no parent"
+    assert child.parent_span_id == root.span_id
+    assert grandchild.parent_span_id == child.span_id
+
+    # A single ddtrace trace must stay a single OTLP trace.
+    assert root.trace_id == child.trace_id == grandchild.trace_id
+    assert len({root.span_id, child.span_id, grandchild.span_id}) == 3
+
+
+def test_sibling_spans_share_a_parent(traces: TraceCollector) -> None:
+    traces.configure(service_name="checkout-api")
+
+    with tracer.trace("root"):
+        with tracer.trace("first"):
+            pass
+        with tracer.trace("second"):
+            pass
+
+    spans = traces.collect()
+    root = span_named(spans, "root")
+    assert span_named(spans, "first").parent_span_id == root.span_id
+    assert span_named(spans, "second").parent_span_id == root.span_id
+
+
+def test_remote_parent_context_is_preserved(traces: TraceCollector) -> None:
+    """Covers the branch that builds a parent context for an out-of-process parent."""
+    from ddtrace.trace import Context
+
+    traces.configure(service_name="checkout-api")
+
+    remote_trace_id = 0x1234567890ABCDEF1234567890ABCDEF
+    remote_span_id = 0x1122334455667788
+
+    tracer.context_provider.activate(
+        Context(trace_id=remote_trace_id, span_id=remote_span_id)
+    )
+    with tracer.trace("continued"):
+        pass
+
+    span = span_named(traces.collect(), "continued")
+    assert span.has_parent
+    assert int.from_bytes(span.parent_span_id, "big") == remote_span_id
+    assert int.from_bytes(span.trace_id, "big") == remote_trace_id
+
+
+@pytest.mark.parametrize(
+    ("dd_kind", "expected_otel_kind"),
+    [
+        (DDSpanKind.SERVER, "SPAN_KIND_SERVER"),
+        (DDSpanKind.CLIENT, "SPAN_KIND_CLIENT"),
+        (DDSpanKind.PRODUCER, "SPAN_KIND_PRODUCER"),
+        (DDSpanKind.CONSUMER, "SPAN_KIND_CONSUMER"),
+    ],
+)
+def test_span_kind_is_mapped(
+    traces: TraceCollector, dd_kind: str, expected_otel_kind: str
+) -> None:
+    traces.configure(service_name="checkout-api")
+
+    with tracer.trace("op") as span:
+        span.set_tag("span.kind", dd_kind)
+
+    exported = span_named(traces.collect(), "op")
+    assert exported.kind == expected_otel_kind
+    # The kind is a first-class OTLP field, so it must not also be an attribute.
+    assert "span.kind" not in exported.attributes
+
+
+def test_untagged_span_defaults_to_internal_kind(traces: TraceCollector) -> None:
+    traces.configure(service_name="checkout-api")
+
+    with tracer.trace("op"):
+        pass
+
+    assert span_named(traces.collect(), "op").kind == "SPAN_KIND_INTERNAL"
+
+
+def test_string_tags_become_span_attributes(any_traces: TraceCollector) -> None:
+    any_traces.configure(service_name="checkout-api")
+
+    with tracer.trace("op") as span:
+        span.set_tag("http.method", "GET")
+        span.set_tags({"http.route": "/orders", "customer.segment": "b2b"})
+
+    exported = span_named(any_traces.collect(), "op")
+    assert exported.attributes["http.method"] == "GET"
+    assert exported.attributes["http.route"] == "/orders"
+    assert exported.attributes["customer.segment"] == "b2b"
+
+
+def test_numeric_metrics_become_numeric_attributes(any_traces: TraceCollector) -> None:
+    """The only "metrics" surface troncos has.
+
+    Span.set_metric writes into Span._metrics, which troncos folds into span
+    attributes. Arriving as strings would break numeric queries in the backend.
+    """
+    any_traces.configure(service_name="checkout-api")
+
+    with tracer.trace("op") as span:
+        span.set_metric("http.status_code", 200)
+        span.set_metric("db.rows_returned", 42)
+        span.set_metric("cache.hit_ratio", 0.75)
+
+    exported = span_named(any_traces.collect(), "op")
+
+    assert exported.attributes["http.status_code"] == 200
+    assert isinstance(exported.attributes["http.status_code"], int)
+
+    assert exported.attributes["db.rows_returned"] == 42
+    assert isinstance(exported.attributes["db.rows_returned"], int)
+
+    assert exported.attributes["cache.hit_ratio"] == pytest.approx(0.75)
+    assert isinstance(exported.attributes["cache.hit_ratio"], float)
+
+
+def test_tracer_wide_tags_are_exported(traces: TraceCollector) -> None:
+    """tracer.set_tags is the README's recommended way to tag every span."""
+    traces.configure(service_name="checkout-api")
+    tracer.set_tags({"deployment.colour": "green"})
+    try:
+        with tracer.trace("op"):
+            pass
+
+        exported = span_named(traces.collect(), "op")
+        assert exported.attributes["deployment.colour"] == "green"
+    finally:
+        # tracer tags are process-wide; don't leak into other tests.
+        tracer._tags.pop("deployment.colour", None)
+
+
+def test_internal_ddtrace_attributes_are_not_exported(
+    any_traces: TraceCollector,
+) -> None:
+    """Datadog bookkeeping must not leak into OTLP spans."""
+    any_traces.configure(service_name="checkout-api")
+
+    with tracer.trace("op"):
+        pass
+
+    exported = span_named(any_traces.collect(), "op")
+    assert "runtime-id" not in exported.attributes
+    assert "_sampling_priority_v1" not in exported.attributes
+    assert not [key for key in exported.attributes if key.startswith("_dd")]
+
+
+def test_exception_is_exported_as_error_status_and_event(
+    any_traces: TraceCollector,
+) -> None:
+    any_traces.configure(service_name="checkout-api")
+
+    with pytest.raises(ValueError):
+        with tracer.trace("op"):
+            raise ValueError("payment declined")
+
+    exported = span_named(any_traces.collect(), "op")
+
+    assert exported.status_code == "STATUS_CODE_ERROR"
+
+    events = exported.exception_events
+    assert len(events) == 1, "expected exactly one 'exception' event"
+    attributes = events[0].attributes
+
+    assert attributes["exception.type"] == "builtins.ValueError"
+    assert attributes["exception.message"] == "payment declined"
+    assert "ValueError: payment declined" in attributes["exception.stacktrace"]
+
+    # The status description should name both, so it is useful on its own.
+    assert "builtins.ValueError" in exported.status_message
+    assert "payment declined" in exported.status_message
+
+
+def test_error_details_are_not_left_as_raw_ddtrace_attributes(
+    traces: TraceCollector,
+) -> None:
+    traces.configure(service_name="checkout-api")
+
+    with pytest.raises(ValueError):
+        with tracer.trace("op"):
+            raise ValueError("payment declined")
+
+    exported = span_named(traces.collect(), "op")
+    leaked = [key for key in exported.attributes if key.startswith("error.")]
+    assert not leaked, f"ddtrace error tags leaked as span attributes: {leaked}"
+
+
+def test_successful_span_has_unset_status(traces: TraceCollector) -> None:
+    traces.configure(service_name="checkout-api")
+
+    with tracer.trace("op"):
+        pass
+
+    exported = span_named(traces.collect(), "op")
+    assert exported.status_code == "STATUS_CODE_UNSET"
+    assert exported.exception_events == []
+
+
+def test_trace_block_exports_a_span(traces: TraceCollector) -> None:
+    traces.configure(service_name="checkout-api")
+
+    with trace_block("cool.block", resource="data!", attributes={"some": "attribute"}):
+        pass
+
+    exported = span_named(traces.collect(), "cool.block")
+    assert exported.attributes["some"] == "attribute"
+    assert exported.attributes["resource"] == "data!"
+
+
+def test_trace_function_exports_a_span(traces: TraceCollector) -> None:
+    traces.configure(service_name="checkout-api")
+
+    @trace_function(name="decorated.sync", attributes={"kind": "sync"})
+    def work() -> int:
+        return 7
+
+    assert work() == 7
+
+    exported = span_named(traces.collect(), "decorated.sync")
+    assert exported.attributes["kind"] == "sync"
+
+
+@pytest.mark.asyncio
+async def test_trace_function_exports_a_span_for_coroutines(
+    traces: TraceCollector,
+) -> None:
+    traces.configure(service_name="checkout-api")
+
+    @trace_function(name="decorated.async")
+    async def work() -> int:
+        return 7
+
+    assert await work() == 7
+
+    span_named(traces.collect(), "decorated.async")
+
+
+def test_trace_class_exports_spans_and_honours_trace_ignore(
+    traces: TraceCollector,
+) -> None:
+    traces.configure(service_name="checkout-api")
+
+    @trace_class
+    class Service:
+        def traced(self) -> None:
+            pass
+
+        @trace_ignore
+        def untraced(self) -> None:
+            pass
+
+    service = Service()
+    service.traced()
+    service.untraced()
+
+    spans = traces.collect()
+    names = [span.name for span in spans]
+    assert any(name.endswith("Service.traced") for name in names), names
+    assert not any(name.endswith("Service.untraced") for name in names), names
+
+
+def test_nested_decorated_calls_keep_their_hierarchy(traces: TraceCollector) -> None:
+    traces.configure(service_name="checkout-api")
+
+    @trace_function(name="outer")
+    def outer() -> None:
+        inner()
+
+    @trace_function(name="inner")
+    def inner() -> None:
+        pass
+
+    outer()
+
+    spans = traces.collect()
+    assert (
+        span_named(spans, "inner").parent_span_id == span_named(spans, "outer").span_id
+    )
+
+
+def test_exporter_headers_are_sent_to_the_collector(traces: TraceCollector) -> None:
+    traces.configure(
+        service_name="checkout-api", headers={"authorization": "Bearer token"}
+    )
+
+    with tracer.trace("op"):
+        pass
+
+    traces.collect()
+
+    requests = traces.requests()
+    assert requests, "expected at least one export request"
+    for request in requests:
+        assert request.headers.get("authorization") == "Bearer token"
+
+
+def test_payload_is_sent_as_protobuf(traces: TraceCollector) -> None:
+    traces.configure(service_name="checkout-api")
+
+    with tracer.trace("op"):
+        pass
+
+    traces.collect()
+
+    requests = traces.requests()
+    assert requests
+    assert requests[0].headers.get("content-type") == "application/x-protobuf"
+
+
+def test_disabled_writer_exports_nothing(any_traces: TraceCollector) -> None:
+    any_traces.configure(service_name="checkout-api", enabled=False)
+
+    with tracer.trace("op"):
+        pass
+
+    assert any_traces.collect() == []
+    assert any_traces.requests() == []
+
+
+def test_disabled_writer_does_not_even_queue_spans(traces: TraceCollector) -> None:
+    """A disabled writer must drop spans, not just refuse to flush them.
+
+    flush_queue() is disabled too, so the test above stays green even if spans
+    are still queued on the batch processor, where the processor's own timer
+    would eventually ship them. Flush the processors directly to prove
+    otherwise.
+    """
+    traces.configure(service_name="checkout-api", enabled=False)
+
+    with tracer.trace("op"):
+        pass
+
+    # Test-only introspection: reach the installed writer and flush its
+    # processors directly, bypassing the disabled flush_queue().
+    writer: Any = tracer._span_aggregator.writer
+    for span_processor in writer.otel_span_processors:
+        span_processor.force_flush()
+
+    assert traces.requests() == [], "a disabled writer queued spans for export"
+
+
+def test_many_spans_are_all_exported(any_traces: TraceCollector) -> None:
+    any_traces.configure(service_name="checkout-api")
+
+    span_count = 200
+    for index in range(span_count):
+        with tracer.trace(f"op-{index}"):
+            pass
+
+    spans = any_traces.collect()
+    exported_names = {span.name for span in spans}
+    missing = {f"op-{index}" for index in range(span_count)} - exported_names
+    assert not missing, f"{len(missing)} spans were never exported"
+
+
+def test_default_exporter_targets_the_otlp_http_endpoint() -> None:
+    exporter = Exporter(host="collector.example.com")
+
+    assert exporter.endpoint == "http://collector.example.com:4318/v1/traces"
+    assert exporter.exporter_type == ExporterType.HTTP
+
+
+def test_grpc_exporter_can_be_constructed(traces: TraceCollector) -> None:
+    """Construction-only smoke test for the optional grpc extra.
+
+    What breaks on an upgrade is the import path or the constructor signature,
+    and building the writer exercises both without a collector. Everything
+    past construction is covered by the tests that run against a real gRPC
+    collector, below.
+    """
+    pytest.importorskip("opentelemetry.exporter.otlp.proto.grpc.trace_exporter")
+
+    from troncos.tracing import create_trace_writer
+
+    writer = create_trace_writer(
+        enabled=True,
+        service_name="checkout-api",
+        exporter=Exporter(host="127.0.0.1", port="4317"),
+    )
+    try:
+        assert writer.exporter.exporter_type == ExporterType.GRPC
+        assert writer.exporter.endpoint == "http://127.0.0.1:4317/"
+        assert writer.otel_span_processors
+    finally:
+        writer.stop()
+
+
+@pytest.mark.filterwarnings("ignore::ResourceWarning")
+@pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
+def test_debug_processor_writes_spans_to_a_file(
+    traces: TraceCollector, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Exercises ConsoleSpanExporter and SimpleSpanProcessor, two more OTel symbols.
+
+    The filters are not incidental: troncos opens the debug file in
+    get_otel_span_processors and nothing closes it, because
+    ConsoleSpanExporter.shutdown() leaves its `out` stream alone. Drop the
+    filters once the handle is closed on writer shutdown.
+    """
+    debug_file = tmp_path / "spans.log"
+    monkeypatch.setenv("OTEL_TRACE_DEBUG", "true")
+    monkeypatch.setenv("OTEL_TRACE_DEBUG_FILE", str(debug_file))
+
+    traces.configure(service_name="checkout-api")
+
+    with tracer.trace("debugged", service="checkout-api"):
+        pass
+
+    # The debug processor exports on span end, so the file is written before
+    # the OTLP flush; collect() still confirms the normal path kept working.
+    span_named(traces.collect(), "debugged")
+
+    assert debug_file.exists(), "OTEL_TRACE_DEBUG_FILE was never created"
+    contents = debug_file.read_text()
+    assert "debugged" in contents, contents[:500]
+    assert "checkout-api" in contents, contents[:500]
+
+
+def test_debug_processor_is_off_by_default(traces: TraceCollector) -> None:
+    traces.configure(service_name="checkout-api")
+
+    writer: Any = tracer._span_aggregator.writer
+    assert len(writer.otel_span_processors) == 1, (
+        "expected only the OTLP batch processor when OTEL_TRACE_DEBUG is unset"
+    )
+
+
+def test_collector_path_is_configurable(traces: HttpTraceCollector) -> None:
+    custom_path = "/custom/otlp/v1/traces"
+    traces._httpserver.expect_request(custom_path).respond_with_data("OK")
+    traces.configure(service_name="checkout-api", path=custom_path)
+
+    with tracer.trace("op", service="checkout-api"):
+        pass
+
+    spans = traces.collect(path=custom_path)
+    assert span_named(spans, "op").service_name == "checkout-api"
+    assert traces.requests(path=COLLECTOR_PATH) == []
+
+
+def test_grpc_export_reaches_a_real_grpc_collector(
+    grpc_traces: GrpcTraceCollector,
+) -> None:
+    """The gRPC path end to end, which construction alone cannot show.
+
+    Alloy's OTLP receiver listens on gRPC at 4317, so this is the transport a
+    large share of deployments actually use. Between troncos and the collector
+    sit the gRPC exporter's endpoint parsing, its insecure-channel decision and
+    the protobuf service definition -- none of which the HTTP tests touch.
+    """
+    grpc_traces.configure(
+        service_name="checkout-api", resource_attributes={"app": "checkout"}
+    )
+
+    with tracer.trace("handle-request", service="checkout-api") as span:
+        span.set_tag("http.method", "GET")
+
+    exported = span_named(grpc_traces.collect(), "handle-request")
+    assert exported.service_name == "checkout-api"
+    assert exported.resource_attributes["app"] == "checkout"
+    assert exported.attributes["http.method"] == "GET"
+
+    assert grpc_traces.requests(), "nothing reached the gRPC collector"
+
+
+def test_grpc_and_http_transports_export_the_same_payload(
+    traces: HttpTraceCollector, grpc_traces: GrpcTraceCollector
+) -> None:
+    """Same workload, both transports, identical spans.
+
+    The two exporters share troncos' translation but not their own encoding, so
+    a divergence here means one transport is losing or reshaping data. Ids and
+    timestamps differ between the two runs by definition and are compared
+    structurally instead.
+    """
+
+    def workload() -> None:
+        with tracer.trace("root", service="checkout-api") as root:
+            root.set_tag("http.method", "GET")
+            root.set_metric("http.status_code", 200)
+            with tracer.trace("child", service="checkout-db"):
+                pass
+
+    def comparable(collector: TraceCollector) -> list[tuple[Any, ...]]:
+        spans = collector.collect()
+        return sorted(
+            (
+                span.name,
+                span.kind,
+                span.status_code,
+                span.has_parent,
+                tuple(sorted(span.attributes.items())),
+                tuple(sorted(span.resource_attributes.items())),
+            )
+            for span in spans
+        )
+
+    resource_attributes = {"app": "checkout"}
+
+    traces.configure(
+        service_name="checkout-api", resource_attributes=resource_attributes
+    )
+    workload()
+    over_http = comparable(traces)
+
+    grpc_traces.configure(
+        service_name="checkout-api", resource_attributes=resource_attributes
+    )
+    workload()
+    over_grpc = comparable(grpc_traces)
+
+    assert over_http, "the HTTP run exported nothing to compare against"
+    assert over_grpc == over_http
+
+
+def test_grpc_exporter_headers_arrive_as_call_metadata(
+    grpc_traces: GrpcTraceCollector,
+) -> None:
+    """Exporter headers become gRPC call metadata.
+
+    This is how a project authenticates to Grafana Cloud or names a tenant, and
+    gRPC carries them as metadata rather than HTTP headers, so the HTTP header
+    test says nothing about this path.
+    """
+    grpc_traces.configure(
+        service_name="checkout-api",
+        headers={"authorization": "Bearer token", "x-scope-orgid": "tenant-7"},
+    )
+
+    with tracer.trace("op"):
+        pass
+
+    grpc_traces.collect()
+
+    requests = grpc_traces.requests()
+    assert requests, "expected at least one export request"
+    for request in requests:
+        assert request.metadata["authorization"] == "Bearer token"
+        assert request.metadata["x-scope-orgid"] == "tenant-7"
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "troncos passes exporter headers to the gRPC exporter verbatim, and gRPC "
+        "rejects any metadata key containing an uppercase character, failing the "
+        "whole export. Header names are case-insensitive over HTTP, so the same "
+        "configuration works there. Remove this marker once troncos lowercases "
+        "header keys."
+    ),
+)
+def test_grpc_export_survives_a_header_key_that_is_not_lowercase(
+    grpc_traces: GrpcTraceCollector,
+) -> None:
+    """`X-Scope-OrgID` is the spelling Grafana's own docs use.
+
+    Configured against gRPC it currently drops every span, silently as far as
+    the application is concerned: gRPC logs to stderr and the exporter reports
+    a failed export, but nothing raises.
+    """
+    grpc_traces.configure(
+        service_name="checkout-api", headers={"X-Scope-OrgID": "tenant-7"}
+    )
+
+    with tracer.trace("op"):
+        pass
+
+    span_named(grpc_traces.collect(), "op")

--- a/tests/tracing/test_perf.py
+++ b/tests/tracing/test_perf.py
@@ -1,0 +1,268 @@
+"""Performance tests for the troncos trace pipeline.
+
+Arm names carry the OTLP transport as a suffix: `troncos-http` and
+`troncos-grpc` are the same implementation over HTTP (4318) and gRPC (4317), and
+each gate compares troncos against the arm on the same transport. The `-grpc`
+arms need the optional `grpc` extra; without it they drop out of the arm list and
+the gate that needs them skips.
+
+The ratio tests always run and are the regression gate: ratios between arms stay
+meaningful on a shared CI runner where absolute timings do not. The
+pytest-benchmark tests record absolute timings and are opt-in via
+`make benchmark`.
+
+Each arm is timed over GATE_ROUNDS rounds and summarised twice. The reported
+number is the mean with its relative spread, because that is the number worth
+quoting. The gates compare medians, because the round distribution has a right
+tail: measured over 750 rounds, 12 ran more than 1.25x their arm's median and 10
+of those coincided with a generation-2 GC pass. The tail hits every arm about
+equally, so it is the runner rather than any one implementation. The mean
+follows those rounds and the median does not, which makes the median the more
+reproducible basis for a gate: over 12 trials the run-to-run standard deviation
+of the ratio was 0.036 on medians against 0.045 on means.
+
+    TRONCOS_PERF_ARMS=opentelemetry-http,troncos-http make perf
+    TRONCOS_PERF_MAX_DDTRACE_RATIO=6 make perf
+"""
+
+import os
+import statistics
+import time
+from collections.abc import Callable, Iterator
+from dataclasses import dataclass
+
+import pytest
+
+from tests.tracing.perf import (
+    NullCollector,
+    build_arm,
+    selected_arms,
+    spans_per_iteration,
+)
+
+ITERATIONS = 50
+
+# 25 rounds rather than a handful, because 7 was not enough to settle: the
+# run-to-run standard deviation of the gate ratio drops from 0.062 to 0.036 on
+# medians, and from 0.094 to 0.045 on means. Timing all five arms costs about
+# 1.2s, which the normal test run can afford.
+GATE_ROUNDS = 25
+GATE_WARMUP_ROUNDS = 5
+
+# Every gate compares troncos against an arm using the same transport, so the
+# ratios measure translation and encoding rather than the difference between
+# HTTP and gRPC. Limits are roughly 2x what an unloaded machine measures, to
+# catch order-of-magnitude regressions without flaking on a busy runner.
+DEFAULT_MAX_DDTRACE_RATIO = 6.0
+DEFAULT_MAX_OPENTELEMETRY_HTTP_RATIO = 2.5
+DEFAULT_MAX_OPENTELEMETRY_GRPC_RATIO = 2.5
+
+
+def _float_from_env(name: str, default: float) -> float:
+    raw = os.environ.get(name)
+    if not raw:
+        return default
+    return float(raw)
+
+
+@pytest.fixture(scope="module")
+def collector() -> Iterator[NullCollector]:
+    """One collector for the module, matching _timings_cache's scope.
+
+    Function-scoped, every test after the first would bind two more ports and
+    start two more servers for timings that were already cached against the
+    first test's collector.
+    """
+    instance = NullCollector().start()
+    try:
+        yield instance
+    finally:
+        instance.stop()
+
+
+@dataclass(frozen=True)
+class ArmTiming:
+    """Seconds per span for one arm, summarised over GATE_ROUNDS rounds."""
+
+    mean: float
+    median: float
+    rounds: int
+    relative_spread: float
+    """Standard deviation as a fraction of the mean."""
+
+
+def _time_arm(name: str, collector: NullCollector) -> ArmTiming:
+    """Time `name` over several rounds and summarise the per-span cost."""
+    arm = build_arm(name)
+    arm.setup(collector)
+    before = collector.request_count
+    try:
+        for _ in range(GATE_WARMUP_ROUNDS):
+            arm.run(ITERATIONS)
+
+        rounds = []
+        for _ in range(GATE_ROUNDS):
+            start = time.perf_counter()
+            arm.run(ITERATIONS)
+            rounds.append(time.perf_counter() - start)
+    finally:
+        arm.teardown()
+
+    assert collector.request_count > before, (
+        f"the {name} arm never reached the collector, so its timing excludes "
+        "the export it is supposed to measure"
+    )
+
+    spans = ITERATIONS * spans_per_iteration()
+    per_span = [seconds / spans for seconds in rounds]
+    mean = statistics.fmean(per_span)
+    return ArmTiming(
+        mean=mean,
+        median=statistics.median(per_span),
+        rounds=len(per_span),
+        relative_spread=statistics.stdev(per_span) / mean,
+    )
+
+
+@pytest.fixture(scope="module")
+def _timings_cache() -> dict[str, ArmTiming]:
+    return {}
+
+
+def _timings(
+    collector: NullCollector, cache: dict[str, ArmTiming]
+) -> dict[str, ArmTiming]:
+    for name in selected_arms():
+        if name not in cache:
+            cache[name] = _time_arm(name, collector)
+    return cache
+
+
+def test_all_selected_arms_produce_a_timing(
+    collector: NullCollector, _timings_cache: dict[str, ArmTiming]
+) -> None:
+    timings = _timings(collector, _timings_cache)
+
+    assert set(timings) >= set(selected_arms())
+    for name, timing in timings.items():
+        assert timing.rounds == GATE_ROUNDS, f"{name} was not timed fully"
+        assert timing.median > 0, f"{name} reported a zero cost"
+        # Bounds the same statistic the gates compare, so a pathological tail
+        # cannot pass one check and fail the other. More than a millisecond per
+        # span means a real network round trip landed on the measured path.
+        assert timing.median < 1e-3, (
+            f"{name} took {timing.median * 1e6:.1f}us per span, "
+            "which suggests the collector ended up on the measured path"
+        )
+
+
+def test_troncos_http_overhead_over_ddtrace_is_bounded(
+    collector: NullCollector, _timings_cache: dict[str, ArmTiming]
+) -> None:
+    if not {"ddtrace", "troncos-http"} <= set(selected_arms()):
+        pytest.skip("needs both the 'ddtrace' and 'troncos-http' arms")
+
+    timings = _timings(collector, _timings_cache)
+    ratio = timings["troncos-http"].median / timings["ddtrace"].median
+    limit = _float_from_env("TRONCOS_PERF_MAX_DDTRACE_RATIO", DEFAULT_MAX_DDTRACE_RATIO)
+
+    assert ratio <= limit, (
+        f"troncos is {ratio:.2f}x slower per span than ddtrace's own exporter "
+        f"(limit {limit:.2f}x). "
+        f"ddtrace={timings['ddtrace'].median * 1e6:.2f}us/span, "
+        f"troncos-http={timings['troncos-http'].median * 1e6:.2f}us/span"
+    )
+
+
+def test_troncos_http_overhead_over_opentelemetry_http_is_bounded(
+    collector: NullCollector, _timings_cache: dict[str, ArmTiming]
+) -> None:
+    if not {"opentelemetry-http", "troncos-http"} <= set(selected_arms()):
+        pytest.skip("needs both the 'opentelemetry-http' and 'troncos-http' arms")
+
+    timings = _timings(collector, _timings_cache)
+    ratio = timings["troncos-http"].median / timings["opentelemetry-http"].median
+    limit = _float_from_env(
+        "TRONCOS_PERF_MAX_OPENTELEMETRY_HTTP_RATIO",
+        DEFAULT_MAX_OPENTELEMETRY_HTTP_RATIO,
+    )
+
+    assert ratio <= limit, (
+        f"troncos is {ratio:.2f}x slower per span than the OpenTelemetry SDK "
+        f"over HTTP (limit {limit:.2f}x). "
+        f"opentelemetry-http="
+        f"{timings['opentelemetry-http'].median * 1e6:.2f}us/span, "
+        f"troncos-http={timings['troncos-http'].median * 1e6:.2f}us/span"
+    )
+
+
+def test_troncos_grpc_overhead_over_opentelemetry_grpc_is_bounded(
+    collector: NullCollector, _timings_cache: dict[str, ArmTiming]
+) -> None:
+    """The same gate as above, on the transport Alloy usually receives on.
+
+    Compared against the OpenTelemetry SDK over gRPC rather than over HTTP, so a
+    regression in troncos' translation shows up while the cost difference
+    between the two transports cancels out.
+    """
+    if not {"opentelemetry-grpc", "troncos-grpc"} <= set(selected_arms()):
+        pytest.skip("needs both the 'opentelemetry-grpc' and 'troncos-grpc' arms")
+
+    timings = _timings(collector, _timings_cache)
+    ratio = timings["troncos-grpc"].median / timings["opentelemetry-grpc"].median
+    limit = _float_from_env(
+        "TRONCOS_PERF_MAX_OPENTELEMETRY_GRPC_RATIO",
+        DEFAULT_MAX_OPENTELEMETRY_GRPC_RATIO,
+    )
+
+    assert ratio <= limit, (
+        f"troncos is {ratio:.2f}x slower per span than the OpenTelemetry SDK "
+        f"over gRPC (limit {limit:.2f}x). "
+        f"opentelemetry-grpc="
+        f"{timings['opentelemetry-grpc'].median * 1e6:.2f}us/span, "
+        f"troncos-grpc={timings['troncos-grpc'].median * 1e6:.2f}us/span"
+    )
+
+
+def test_report_arm_timings(
+    collector: NullCollector,
+    _timings_cache: dict[str, ArmTiming],
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Print the comparison table so a CI log shows the actual numbers."""
+    timings = _timings(collector, _timings_cache)
+    baseline = min(timing.median for timing in timings.values())
+    rounds = next(iter(timings.values())).rounds
+
+    lines = [
+        "",
+        f"per-span cost by arm over {rounds} rounds (lower is better). "
+        "The gates compare medians:",
+        f"  {'arm':<20}{'mean':>12}{'spread':>10}{'median':>12}{'vs fastest':>12}",
+    ]
+    for name, timing in sorted(timings.items(), key=lambda item: item[1].median):
+        lines.append(
+            f"  {name:<20}"
+            f"{timing.mean * 1e6:9.2f} us"
+            f"{timing.relative_spread:10.1%}"
+            f"{timing.median * 1e6:9.2f} us"
+            f"{timing.median / baseline:11.2f}x"
+        )
+
+    with capsys.disabled():
+        print("\n".join(lines))
+
+    assert timings
+
+
+@pytest.mark.benchmark(group="span-pipeline")
+@pytest.mark.parametrize("arm_name", selected_arms())
+def test_benchmark_span_pipeline(
+    benchmark: Callable[..., None], collector: NullCollector, arm_name: str
+) -> None:
+    arm = build_arm(arm_name)
+    arm.setup(collector)
+    try:
+        benchmark(arm.run, ITERATIONS)
+    finally:
+        arm.teardown()

--- a/troncos/tracing/_span.py
+++ b/troncos/tracing/_span.py
@@ -59,15 +59,14 @@ def _span_kind(dd_span: DDSpan) -> SpanKind:
     return _span_kind_map.get(dd_kind, SpanKind.INTERNAL)
 
 
+# Keys come from ddtrace rather than being hardcoded: ddtrace 4.x renamed
+# "error.msg" to "error.message", which silently dropped exception messages from
+# exported spans. The pre-4.x names stay mapped so a downgrade cannot bring the
+# same data loss back.
 _dd_span_err_attr_mapping = {
-    # Read the keys off ddtrace instead of hardcoding them: ddtrace renamed
-    # "error.msg" to "error.message" in 4.x, which silently dropped the
-    # exception message from exported spans.
     constants.ERROR_MSG: "exception.message",
     constants.ERROR_TYPE: "exception.type",
     constants.ERROR_STACK: "exception.stacktrace",
-    # Keys used by older ddtrace releases, kept so a downgrade does not
-    # reintroduce the same silent data loss.
     "error.msg": "exception.message",
     "error.type": "exception.type",
     "error.stack": "exception.stacktrace",


### PR DESCRIPTION
Troncos sits between ddtrace and OpenTelemetry and leans on internals of
both, which makes dependency upgrades the main standing risk to the
project: a bump can stop traces from being exported correctly without
anything failing to import. The existing tests reached into private
modules and asserted on raw bytes, so they broke on refactors while
saying little about whether tracing still worked.

Move the suite towards testing behaviour rather than internals. A new
end-to-end suite drives only the public API, exports to a local
collector, and checks what actually arrives on the wire one translated
field at a time, so a failure names what stopped working. It was
developed against deliberately injected translation faults to confirm it
catches them. The debug span processor is covered the same way.

Both OTLP transports are covered, since the README recommends gRPC for
production and Grafana Alloy commonly receives on 4317, so the path a
large share of deployments use should not go untested. The test
collector is split per transport: the payload assertions (service name,
resource attributes, span tree, tags, metrics, error status, batching,
disabled writer) run over HTTP and gRPC alike, transport-specific
details such as the HTTP path, content type and headers stay with their
transport, and one test pins that both transports export the same
payload for the same workload.

Give performance the same treatment. The bridge only does its work when
spans are exported, so the suite runs one workload through ddtrace,
plain OpenTelemetry and troncos, each exporting for real, and compares
them. Every gate compares troncos against an arm on the same transport,
so the ratio measures translation cost rather than the difference
between HTTP and gRPC. Relative cost is the gate, since ratios stay
meaningful on a shared CI runner where absolute timings do not; detailed
benchmarking is opt-in for when someone is actually optimising, which
also replaces a test config option left pointing at a directory removed
years ago.
