### PR TITLE
feat: add profiling that pushes to Grafana Pyroscope

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@
 - [Etymology](#etymology)
 - [Installation](#installation)
 - [Tracing](#tracing)
+- [Profiling](#profiling)
 - [Logging](#logging)
 <!-- TOC -->
 
@@ -362,6 +363,165 @@ from troncos.contrib.celery.logging.signals import (
 
 connect_troncos_logging_celery_signals()
 ```
+
+## Profiling
+
+Troncos ships a continuous profiler that pushes to [Grafana Pyroscope](https://grafana.com/docs/pyroscope/latest/),
+built on Grafana's own [`pyroscope-io`](https://github.com/grafana/pyroscope-python) SDK.
+Sampling is done by [py-spy](https://github.com/benfred/py-spy) in native threads that
+read the interpreter's memory directly. They never execute Python or take the GIL, so
+they do not show up in `threading.active_count()` and do not contend with your code.
+
+The SDK is a compiled wheel of several megabytes, so it is an extra:
+
+```console
+uv add "troncos[profiling]"
+```
+
+or
+
+```toml
+[project]
+dependencies = ["troncos[profiling]"]
+```
+
+### Enabling the profiler
+
+`PYROSCOPE_HOST` and `PYROSCOPE_PORT` are usually the hostname and port of Pyroscope
+itself, or of a Grafana Alloy instance relaying to it. The port is `4040` by default.
+
+```python
+from troncos.profiling import configure_profiler, Exporter
+
+
+def setup_profiling() -> None:
+    configure_profiler(
+        service_name='SERVICE_NAME',
+        exporter=Exporter(
+            # Usually obtained from env variables.
+            host="pyroscope.monitoring.svc.cluster.local",
+        ),
+        tags={
+            "role": "web",
+        },
+        enabled=True,
+    )
+```
+
+`service_name` is required, but it falls back to the ddtrace service name, so it
+can be omitted when `DD_SERVICE` is set or tracing is already configured. There is
+no default: Pyroscope groups profiles by this name, so troncos raises rather than
+invent one. Profiles are tagged with the service name, hostname,
+`ddtrace` env and version, and any tags already set on the tracer, which lets a
+profile be filtered by the same labels as its traces.
+
+Start the profiler after any subprocesses have forked. The SDK is
+[not fork safe](https://grafana.com/docs/pyroscope/latest/configure-client/language-sdks/python/)
+once its sampling threads are running. This is the same constraint tracing has, so
+the same hooks work:
+
+```python
+from typing import Any
+
+from celery import signals
+
+# gunicorn:
+def post_fork(server: Any, worker: Any) -> None:
+    setup_profiling()
+
+# celery master process
+@signals.worker_ready.connect  # type: ignore
+def worker_ready(**kwargs: Any) -> None:
+    setup_profiling()
+```
+
+Pass `enabled=False` to turn profiling off. Nothing is imported in that case, so a
+service that gates profiling on an env flag runs without the extra installed.
+
+### Authenticating against Grafana Cloud
+
+```python
+from troncos.profiling import configure_profiler, Exporter
+
+
+def setup_grafana_cloud_profiling() -> None:
+    configure_profiler(
+        service_name='SERVICE_NAME',
+        exporter=Exporter(
+            scheme="https",
+            host="profiles-prod-001.grafana.net",
+            port="443",
+            basic_auth_username="123456",
+            basic_auth_password="glc_token",
+        ),
+    )
+```
+
+### What is profiled
+
+By default the profiler samples wall clock time across every thread, not just
+on-CPU time in the thread holding the GIL. A request blocked on a database shows
+up, which is usually what you are looking for. Both are opposite to the SDK's
+own defaults, so set `oncpu=True` if you want CPU time only.
+
+Everything else the SDK takes is on `ProfilerOptions`. Field names match the
+arguments of `pyroscope.configure`, so Grafana's
+[SDK documentation](https://grafana.com/docs/pyroscope/latest/configure-client/language-sdks/python/)
+describes them directly.
+
+```python
+from troncos.profiling import configure_profiler, Exporter, ProfilerOptions, LineNo
+
+
+def setup_detailed_profiling() -> None:
+    configure_profiler(
+        service_name='SERVICE_NAME',
+        exporter=Exporter(host="pyroscope.monitoring.svc.cluster.local"),
+        options=ProfilerOptions(
+            sample_rate=200,          # Samples per second, default 100.
+            upload_interval=15,       # Seconds between uploads, default 10.
+            oncpu=True,               # On-CPU time only, rather than wall clock.
+            report_thread_name=True,  # Split the flamegraph by thread.
+            line_no=LineNo.FIRST,     # Attribute to the first line of a frame.
+            mem_enabled=True,         # Also collect heap profiles.
+        ),
+    )
+```
+
+The options are a frozen dataclass, so a typo is caught by your type checker
+rather than accepted and ignored. Values that Pyroscope would take and then do
+nothing with raise `ValueError` on construction:
+
+```python
+from troncos.profiling import ProfilerOptions
+
+try:
+    ProfilerOptions(sample_rate=0)
+except ValueError as error:
+    print(error)
+```
+
+Turning off both collectors is rejected on the same grounds. Profiling is
+switched off with `configure_profiler(enabled=False)`, which imports nothing, so
+a configuration that starts a profiler in order to collect nothing is a mistake.
+
+### Scraping is not supported
+
+Troncos pushes profiles. It does not serve a `/debug/pprof` endpoint for Pyroscope
+or Grafana Alloy to scrape, because Python has no maintained way to produce pprof
+bytes in process. Point Pyroscope at your service through push instead.
+
+### Coming from troncos v6
+
+Profiling was absent in v7. If you are upgrading from v6:
+
+- `start_py_spy_profiler(server_address=...)` becomes
+  `configure_profiler(exporter=Exporter(...))`.
+- Add the extra. `pyroscope-io` is no longer installed for everyone.
+- Pass credentials as `Exporter(basic_auth_username=..., basic_auth_password=...)`
+  or `Exporter(headers=...)`. The SDK dropped its `auth_token` argument.
+- The pprof endpoint, `troncos.profiling.auto` and the ASGI, Django and Starlette
+  profiling views have no replacement.
 
 ## Logging
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "troncos"
 version = "8.0.2" # x-release-please-version
-description = "Collection of Python logging and tracing tools"
+description = "Collection of Python logging, tracing and profiling tools"
 authors = [
   { name = "Guðmundur Björn Birkisson", email = "gudmundur.birkisson@oda.com" },
   { name = "Karl Fredrik Haugland", email = "karlfredrik.haugland@oda.com" },
@@ -10,7 +10,7 @@ authors = [
 license = "MIT"
 license-files = ["LICENSE"]
 readme = "README.md"
-keywords = ["logs", "traces", "opentelemetry"]
+keywords = ["logs", "traces", "profiles", "opentelemetry"]
 requires-python = ">=3.11,<3.15"
 classifiers = [
   "Programming Language :: Python :: 3",
@@ -32,6 +32,7 @@ Documentation = "https://github.com/kolonialno/troncos"
 
 [project.optional-dependencies]
 grpc = ["opentelemetry-exporter-otlp-proto-grpc>=1.19,<2"]
+profiling = ["pyroscope-io>=1.2,<2"]
 sentry = ["structlog-sentry>=2.0.0,<3"]
 
 [dependency-groups]

--- a/tests/profiling/conftest.py
+++ b/tests/profiling/conftest.py
@@ -1,0 +1,46 @@
+"""Shared fixtures for the profiling tests."""
+
+import inspect
+from collections.abc import Iterator
+from typing import Any, TypeAlias
+
+import pytest
+from ddtrace import config
+from ddtrace.trace import tracer
+
+Configured: TypeAlias = list[dict[str, Any]]
+"""Calls troncos made to `pyroscope.configure`, in order."""
+
+
+@pytest.fixture
+def configured(monkeypatch: pytest.MonkeyPatch) -> Configured:
+    """Capture what troncos would hand the SDK, without starting a profiler.
+
+    Every captured call is bound against the installed `pyroscope.configure`
+    first. The v6 wrapper this replaces passed `auth_token` and
+    `detect_subprocesses`, both of which the SDK has since dropped; binding
+    turns that class of drift into a test failure rather than a TypeError in
+    whichever service upgrades first.
+    """
+    pyroscope = pytest.importorskip("pyroscope", reason="needs the 'profiling' extra")
+
+    signature = inspect.signature(pyroscope.configure)
+    calls: Configured = []
+
+    def record(**kwargs: Any) -> None:
+        signature.bind(**kwargs)
+        calls.append(kwargs)
+
+    monkeypatch.setattr(pyroscope, "configure", record)
+    return calls
+
+
+@pytest.fixture(autouse=True)
+def restore_ddtrace_config() -> Iterator[None]:
+    """Undo the process-wide ddtrace config that tags are derived from."""
+    original = (config.service, config.env, config.version, dict(tracer._tags))
+
+    yield
+
+    config.service, config.env, config.version = original[:3]
+    tracer._tags = original[3]

--- a/tests/profiling/test_options.py
+++ b/tests/profiling/test_options.py
@@ -1,0 +1,104 @@
+import dataclasses
+from typing import Any
+
+import pytest
+
+from troncos.profiling import LineNo, ProfilerOptions, configure_profiler
+
+from tests.profiling.conftest import Configured
+
+pyroscope = pytest.importorskip("pyroscope", reason="needs the 'profiling' extra")
+
+
+def test_every_option_reaches_the_sdk(configured: Configured) -> None:
+    """Field names match `pyroscope.configure`, so each one forwards unchanged."""
+    options = ProfilerOptions(
+        sample_rate=200,
+        oncpu=True,
+        gil_only=True,
+        cpu_enabled=True,
+        upload_interval=15,
+        report_pid=True,
+        report_thread_id=True,
+        report_thread_name=True,
+        enable_logging=True,
+        mem_enabled=True,
+        mem_max_nframe=64,
+        mem_heap_sample_size=1024,
+        mem_enable_mem_domain=False,
+    )
+
+    configure_profiler(service_name="svc", options=options)
+
+    call = configured[0]
+    for field in dataclasses.fields(options):
+        if field.name == "line_no":
+            continue  # Translated rather than forwarded, asserted separately.
+        assert call[field.name] == getattr(options, field.name), field.name
+
+
+def test_defaults_keep_pre_v7_behaviour(configured: Configured) -> None:
+    configure_profiler(service_name="svc")
+
+    call = configured[0]
+    assert call["oncpu"] is False, "the SDK defaults this to True"
+    assert call["gil_only"] is False, "the SDK defaults this to True"
+    assert call["sample_rate"] == 100
+    assert call["upload_interval"] == 10
+
+
+@pytest.mark.parametrize(
+    ("line_no", "variant"),
+    [
+        (LineNo.LAST_INSTRUCTION, "LastInstruction"),
+        (LineNo.FIRST, "First"),
+        (LineNo.NO_LINE, "NoLine"),
+    ],
+)
+def test_line_no_becomes_the_sdk_type(
+    configured: Configured, line_no: LineNo, variant: str
+) -> None:
+    """The SDK's LineNo rejects int and str, so the mirror must resolve to it."""
+    configure_profiler(service_name="svc", options=ProfilerOptions(line_no=line_no))
+
+    assert configured[0]["line_no"] == getattr(pyroscope.LineNo, variant)
+
+
+def test_line_no_mirror_covers_the_sdk() -> None:
+    """A variant added or renamed upstream should fail here, not at runtime."""
+    upstream = {name for name in dir(pyroscope.LineNo) if not name.startswith("_")}
+
+    assert {member.value for member in LineNo} == upstream
+
+
+@pytest.mark.parametrize(
+    "field",
+    ["sample_rate", "upload_interval", "mem_max_nframe", "mem_heap_sample_size"],
+)
+@pytest.mark.parametrize("value", [0, -1])
+def test_non_positive_values_are_rejected(field: str, value: int) -> None:
+    """Pyroscope takes these silently and then collects nothing."""
+    override: dict[str, Any] = {field: value}
+
+    with pytest.raises(ValueError, match=rf"{field} must be greater than 0"):
+        ProfilerOptions(**override)
+
+
+def test_collecting_nothing_is_rejected() -> None:
+    """`configure_profiler(enabled=False)` is how profiling gets switched off."""
+    with pytest.raises(ValueError, match="collect nothing"):
+        ProfilerOptions(cpu_enabled=False, mem_enabled=False)
+
+
+def test_memory_only_is_not_a_no_op() -> None:
+    options = ProfilerOptions(cpu_enabled=False, mem_enabled=True)
+
+    assert options.mem_enabled is True
+
+
+def test_options_are_frozen() -> None:
+    """Shared config that a caller can mutate after the fact is a trap."""
+    options = ProfilerOptions()
+
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        options.sample_rate = 1  # type: ignore[misc]

--- a/tests/profiling/test_profiler.py
+++ b/tests/profiling/test_profiler.py
@@ -1,0 +1,164 @@
+import builtins
+from typing import Any
+
+import pytest
+from ddtrace import config
+from ddtrace.trace import tracer
+
+from troncos.profiling import Exporter, configure_profiler
+
+from tests.profiling.conftest import Configured
+
+pytest.importorskip("pyroscope", reason="needs the 'profiling' extra")
+
+
+def test_defaults_to_local_pyroscope(configured: Configured) -> None:
+    configure_profiler(service_name="svc")
+
+    assert configured[0]["server_address"] == "http://localhost:4040"
+    assert configured[0]["application_name"] == "svc"
+
+
+def test_endpoint_from_environment(
+    configured: Configured, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("PYROSCOPE_HOST", "pyroscope.monitoring.svc.cluster.local")
+    monkeypatch.setenv("PYROSCOPE_PORT", "4041")
+
+    configure_profiler(service_name="svc")
+
+    assert (
+        configured[0]["server_address"]
+        == "http://pyroscope.monitoring.svc.cluster.local:4041"
+    )
+
+
+def test_exporter_carries_credentials(configured: Configured) -> None:
+    configure_profiler(
+        service_name="svc",
+        exporter=Exporter(
+            scheme="https",
+            host="profiles.example.com",
+            port="443",
+            basic_auth_username="user",
+            basic_auth_password="secret",
+            tenant_id="tenant",
+            headers={"X-Scope-OrgID": "tenant"},
+        ),
+    )
+
+    call = configured[0]
+    assert call["server_address"] == "https://profiles.example.com:443"
+    assert call["basic_auth_username"] == "user"
+    assert call["basic_auth_password"] == "secret"
+    assert call["tenant_id"] == "tenant"
+    assert call["http_headers"] == {"X-Scope-OrgID": "tenant"}
+
+
+def test_service_name_falls_back_to_ddtrace(configured: Configured) -> None:
+    config.service = "from-ddtrace"
+
+    configure_profiler()
+
+    assert configured[0]["application_name"] == "from-ddtrace"
+
+
+def test_service_name_is_required(configured: Configured) -> None:
+    """Pyroscope groups by this name, so a placeholder would pool every service."""
+    config.service = None
+
+    with pytest.raises(ValueError, match="needs a service name"):
+        configure_profiler()
+
+    assert configured == []
+
+
+@pytest.mark.parametrize("blank", ["", "   "])
+def test_blank_service_name_is_rejected(configured: Configured, blank: str) -> None:
+    """Even with a fallback available: a blank override is a mistake, not a request
+    for the ddtrace name, and answering it silently would hide it."""
+    config.service = "from-ddtrace"
+
+    with pytest.raises(ValueError, match="needs a service name"):
+        configure_profiler(service_name=blank)
+
+    assert configured == []
+
+
+def test_surrounding_whitespace_is_trimmed(configured: Configured) -> None:
+    configure_profiler(service_name="  svc  ")
+
+    assert configured[0]["application_name"] == "svc"
+
+
+def test_tags_describe_the_deployment(configured: Configured) -> None:
+    config.env = "prod"
+    config.version = "1.2.3"
+
+    configure_profiler(service_name="svc")
+
+    tags = configured[0]["tags"]
+    assert tags["app"] == "svc"
+    assert tags["env"] == "prod"
+    assert tags["version"] == "1.2.3"
+    assert tags["instance"], "the hostname identifies which replica a profile came from"
+
+
+def test_unset_ddtrace_fields_are_omitted(configured: Configured) -> None:
+    config.env = None
+    config.version = None
+
+    configure_profiler(service_name="svc")
+
+    tags = configured[0]["tags"]
+    assert "env" not in tags, "an empty tag is worse than an absent one to group by"
+    assert "version" not in tags
+
+
+def test_tracer_tags_are_inherited(configured: Configured) -> None:
+    tracer.set_tags({"owner": "team-a"})
+
+    configure_profiler(service_name="svc")
+
+    assert configured[0]["tags"]["owner"] == "team-a"
+
+
+def test_explicit_tags_win(configured: Configured) -> None:
+    tracer.set_tags({"owner": "team-a"})
+
+    configure_profiler(service_name="svc", tags={"owner": "team-b", "role": "worker"})
+
+    tags = configured[0]["tags"]
+    assert tags["owner"] == "team-b"
+    assert tags["role"] == "worker"
+
+
+def test_disabled_starts_nothing(configured: Configured) -> None:
+    configure_profiler(service_name="svc", enabled=False)
+
+    assert configured == []
+
+
+def test_disabled_does_not_need_the_extra(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A service gated on an env flag must import and run without pyroscope."""
+    monkeypatch.setattr(builtins, "__import__", _refusing_to_import("pyroscope"))
+
+    configure_profiler(service_name="svc", enabled=False)
+
+
+def test_missing_extra_says_how_to_install(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(builtins, "__import__", _refusing_to_import("pyroscope"))
+
+    with pytest.raises(ImportError, match=r"troncos\[profiling\]"):
+        configure_profiler(service_name="svc")
+
+
+def _refusing_to_import(name: str) -> Any:
+    real = builtins.__import__
+
+    def guarded(module: str, *args: Any, **kwargs: Any) -> Any:
+        if module == name:
+            raise ImportError(f"No module named {name!r}")
+        return real(module, *args, **kwargs)
+
+    return guarded

--- a/troncos/profiling/__init__.py
+++ b/troncos/profiling/__init__.py
@@ -1,0 +1,123 @@
+from typing import Any
+
+from ddtrace import config
+from ddtrace.internal.hostname import get_hostname
+from ddtrace.trace import tracer
+
+from ._exporter import Exporter
+from ._options import LineNo, ProfilerOptions
+
+__all__ = [
+    "Exporter",
+    "LineNo",
+    "ProfilerOptions",
+    "configure_profiler",
+    "stop_profiler",
+]
+
+
+def _pyroscope() -> Any:
+    try:
+        import pyroscope
+    except ImportError as exc:
+        raise ImportError(
+            "Profiling needs the 'profiling' extra: pip install 'troncos[profiling]'"
+        ) from exc
+
+    return pyroscope
+
+
+def _resolve_app_name(service_name: str | None) -> str:
+    """Name the profiled service, refusing to invent one.
+
+    Profiles are grouped by this name in Pyroscope, so a placeholder would put
+    every unnamed service in one pile.
+    """
+    # Omitting the argument asks for the ddtrace name. Passing a blank one is a
+    # mistake, and silently answering it with the fallback would hide it.
+    if service_name is None:
+        app_name = (config.service or "").strip()
+    else:
+        app_name = service_name.strip()
+
+    if not app_name:
+        raise ValueError(
+            "Profiling needs a service name. Pass "
+            "configure_profiler(service_name=...), or set the DD_SERVICE "
+            "environment variable for ddtrace to pick up."
+        )
+
+    return app_name
+
+
+def _build_tags(*, app_name: str, tags: dict[str, str] | None) -> dict[str, str]:
+    profiler_tags = {"app": app_name, "instance": get_hostname()}
+
+    if config.env:
+        profiler_tags["env"] = config.env
+    if config.version:
+        profiler_tags["version"] = config.version
+
+    # Whatever the application already declared on the tracer, so a profile can
+    # be filtered by the same labels as its traces.
+    profiler_tags.update({k: str(v) for k, v in tracer._tags.items()})
+
+    if tags:
+        profiler_tags.update(tags)
+
+    return profiler_tags
+
+
+def configure_profiler(
+    *,
+    service_name: str | None = None,
+    exporter: Exporter | None = None,
+    tags: dict[str, str] | None = None,
+    options: ProfilerOptions | None = None,
+    enabled: bool = True,
+) -> None:
+    """Configure the continuous profiler to push profiles to Grafana Pyroscope."""
+
+    if not enabled:
+        return
+
+    if exporter is None:
+        exporter = Exporter()
+    if options is None:
+        options = ProfilerOptions()
+
+    app_name = _resolve_app_name(service_name)
+
+    pyroscope = _pyroscope()
+
+    pyroscope.configure(
+        application_name=app_name,
+        server_address=exporter.endpoint,
+        basic_auth_username=exporter.basic_auth_username,
+        basic_auth_password=exporter.basic_auth_password,
+        tenant_id=exporter.tenant_id,
+        http_headers=exporter.headers,
+        tags=_build_tags(app_name=app_name, tags=tags),
+        sample_rate=options.sample_rate,
+        oncpu=options.oncpu,
+        gil_only=options.gil_only,
+        cpu_enabled=options.cpu_enabled,
+        upload_interval=options.upload_interval,
+        report_pid=options.report_pid,
+        report_thread_id=options.report_thread_id,
+        report_thread_name=options.report_thread_name,
+        # The SDK's LineNo is a native type that rejects both int and str, so
+        # troncos' mirror of it is resolved back by variant name.
+        line_no=getattr(pyroscope.LineNo, options.line_no.value),
+        enable_logging=options.enable_logging,
+        mem_enabled=options.mem_enabled,
+        mem_max_nframe=options.mem_max_nframe,
+        mem_heap_sample_size=options.mem_heap_sample_size,
+        mem_enable_mem_domain=options.mem_enable_mem_domain,
+    )
+
+
+def stop_profiler() -> None:
+    """Stop the profiler and flush what it has collected."""
+
+    _pyroscope().shutdown()

--- a/troncos/profiling/_exporter.py
+++ b/troncos/profiling/_exporter.py
@@ -1,0 +1,27 @@
+import os
+
+
+class Exporter:
+    """Where profiles are pushed, and how to authenticate against it."""
+
+    def __init__(
+        self,
+        *,
+        scheme: str = "http",
+        host: str | None = None,
+        port: str | None = None,
+        basic_auth_username: str = "",
+        basic_auth_password: str = "",
+        tenant_id: str = "",
+        headers: dict[str, str] | None = None,
+    ) -> None:
+        if host is None:
+            host = os.environ.get("PYROSCOPE_HOST", "localhost")
+        if port is None:
+            port = os.environ.get("PYROSCOPE_PORT", "4040")
+
+        self.endpoint = f"{scheme}://{host}:{port}"
+        self.basic_auth_username = basic_auth_username
+        self.basic_auth_password = basic_auth_password
+        self.tenant_id = tenant_id
+        self.headers = headers

--- a/troncos/profiling/_options.py
+++ b/troncos/profiling/_options.py
@@ -1,0 +1,94 @@
+import enum
+from dataclasses import dataclass
+
+
+class LineNo(enum.Enum):
+    """Which line of a sampled frame the profiler attributes a sample to.
+
+    Values are the names of the SDK's own variants. The SDK's `LineNo` is a
+    native type that only accepts itself, so troncos mirrors it here rather
+    than importing it, which keeps `troncos.profiling` importable without the
+    'profiling' extra.
+    """
+
+    LAST_INSTRUCTION = "LastInstruction"
+    FIRST = "First"
+    NO_LINE = "NoLine"
+
+
+def _require_positive(name: str, value: int) -> None:
+    if value <= 0:
+        raise ValueError(
+            f"{name} must be greater than 0, got {value!r}. Pyroscope accepts "
+            f"the value and then collects nothing, so troncos rejects it here."
+        )
+
+
+@dataclass(frozen=True)
+class ProfilerOptions:
+    """How the profiler samples, on top of the endpoint an `Exporter` names.
+
+    Field names match the arguments of `pyroscope.configure`, so Grafana's
+    [SDK documentation](https://grafana.com/docs/pyroscope/latest/configure-client/language-sdks/python/)
+    describes them directly.
+
+    Two defaults differ from the SDK's own. `oncpu` and `gil_only` are both
+    `False` here and `True` there, which widens profiling from on-CPU time in
+    the GIL-holding thread to wall clock time across every thread, so that time
+    spent waiting is visible.
+    """
+
+    sample_rate: int = 100
+    """Samples per second."""
+
+    oncpu: bool = False
+    """Measure on-CPU time only, rather than wall clock time."""
+
+    gil_only: bool = False
+    """Sample only the thread holding the GIL."""
+
+    cpu_enabled: bool = True
+    """Collect CPU profiles."""
+
+    upload_interval: int = 10
+    """Seconds between uploads."""
+
+    report_pid: bool = False
+    """Tag samples with the process id."""
+
+    report_thread_id: bool = False
+    """Tag samples with the thread id."""
+
+    report_thread_name: bool = False
+    """Tag samples with the thread name."""
+
+    line_no: LineNo = LineNo.LAST_INSTRUCTION
+    """Which line of a frame a sample is attributed to."""
+
+    enable_logging: bool = False
+    """Let the SDK log its own activity, for debugging a silent profiler."""
+
+    mem_enabled: bool = False
+    """Collect heap profiles. Unavailable on free-threaded interpreters."""
+
+    mem_max_nframe: int = 128
+    """Frames to keep per allocation."""
+
+    mem_heap_sample_size: int = 512 * 1024
+    """Bytes allocated between heap samples."""
+
+    mem_enable_mem_domain: bool = True
+    """Track allocator domains, which needs Python 3.12 or newer."""
+
+    def __post_init__(self) -> None:
+        _require_positive("sample_rate", self.sample_rate)
+        _require_positive("upload_interval", self.upload_interval)
+        _require_positive("mem_max_nframe", self.mem_max_nframe)
+        _require_positive("mem_heap_sample_size", self.mem_heap_sample_size)
+
+        if not self.cpu_enabled and not self.mem_enabled:
+            raise ValueError(
+                "cpu_enabled and mem_enabled are both False, so the profiler "
+                "would start and collect nothing. Pass enabled=False to "
+                "configure_profiler to turn profiling off."
+            )

--- a/uv.lock
+++ b/uv.lock
@@ -1634,6 +1634,38 @@ wheels = [
 ]
 
 [[package]]
+name = "pyroscope-io"
+version = "1.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/33/d2/5fc44302f861eb2fd19bf7e56423c93e8867199c647337bb9849bc6d2929/pyroscope_io-1.2.1.tar.gz", hash = "sha256:c3236136dc086845d283fbeb434f5e22f5a7ddc0ff5a5b328752335d61ee1aaf", size = 74584, upload-time = "2026-07-27T11:39:44.57Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5f/f3/0b8c4906c6622c1c1451b52cacc192db41e197d3c6db60b235909e558c94/pyroscope_io-1.2.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:8387470016135a590f43da21a4dfcd47c238e4dfacabccc3e527da6cf61898f7", size = 2116130, upload-time = "2026-07-27T11:39:09.309Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/5c/c925b3a127071d0d06cffb0152db9c452f375d711d77b942f08e77d27d37/pyroscope_io-1.2.1-cp311-cp311-macosx_11_0_x86_64.whl", hash = "sha256:0c8eb803eed4ae7247adb18999afcfb82894c28d67c0b99c63c16fc6443c63cc", size = 2195008, upload-time = "2026-07-27T11:39:10.638Z" },
+    { url = "https://files.pythonhosted.org/packages/85/56/832ab29d946c5b94a1ced1f4547964318c2dc82bb06c8b8501c883dfce2d/pyroscope_io-1.2.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:bebcccb717abddeb59b7df12e693fd0f85b946a20a38bdcfef3491fbac7d827c", size = 5583871, upload-time = "2026-07-27T11:39:12.278Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/7d/9ff9223852965390fb17a6548f129fd73e038584d8d4b5c3e65ba83d8815/pyroscope_io-1.2.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4327785c6087afc084a230aa27107b53070c67555438caf3fce3ac73f821c787", size = 5127972, upload-time = "2026-07-27T11:39:13.636Z" },
+    { url = "https://files.pythonhosted.org/packages/60/e6/fa8917594d1a3cb06e4400b49f95a4760e59e890de48360f9bcc29ca26e9/pyroscope_io-1.2.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:d18f843ef60503f15c9d189dc1aa7f06d8edac9760f252ae6e825805fc7d21e3", size = 5513939, upload-time = "2026-07-27T11:39:15.078Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/ab/d9b6d65f954e6d0d9f95e8468ec61b526c4e2aa3c0332d5b609cd89ad6eb/pyroscope_io-1.2.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:736d569a465edafc5c271d702bfef24e9afd25c06e5ea2e6746bd01ef622e62e", size = 5244667, upload-time = "2026-07-27T11:39:16.554Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/2c/cfaddac31c80b471cc896d3d09ee88d99779861a6b6dc3a7f7d43f12e39e/pyroscope_io-1.2.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:692091ae7d020ee76a16d9da2e213b69c20367d20032ecb643c23e3a5831f87d", size = 2113014, upload-time = "2026-07-27T11:39:18.237Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/d5/188f433e9ab08973948fac72e6aacf2a641a69c45885bed982cc8a768e64/pyroscope_io-1.2.1-cp312-cp312-macosx_11_0_x86_64.whl", hash = "sha256:ceabd42b2d61876eb81668cb76bb04b911d62369645c1c4eb63c9d4ed5106b3c", size = 2196053, upload-time = "2026-07-27T11:39:19.594Z" },
+    { url = "https://files.pythonhosted.org/packages/96/86/fa0bca1756f881b9960c460cef7604e9044bb84a68d9d76cbd3e39372cf3/pyroscope_io-1.2.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:e64e2f34f340b163013b2942017d98bb0a4584e26ae64dfdba3f85304eea8efe", size = 5579568, upload-time = "2026-07-27T11:39:20.804Z" },
+    { url = "https://files.pythonhosted.org/packages/de/1c/a7dac80341fe67ae775a33f9d0da2c04445479be3ce8a96e4b62df210c6e/pyroscope_io-1.2.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:16a39b80e5032fe978eaac6abf907e7b79128357adc0f0d8e7921e68bd57c4ea", size = 5123015, upload-time = "2026-07-27T11:39:22.185Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/90/049e9fda943f6fd01f035783c633d3e83a1a34aa00b1ef1eb325f0b0aa86/pyroscope_io-1.2.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:45f5d7ed4a7a158732d3c1634846011c382309720d891200f64aee3a11173418", size = 5510537, upload-time = "2026-07-27T11:39:23.633Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/9b/f35ccd7935f87aa67a60e158b45f992e2e08243c5c6b432567cf7b1ef194/pyroscope_io-1.2.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:7bc01f8b5c49efca59987194c28667559b1fbded965943d020d12aadc40d0c5c", size = 5239529, upload-time = "2026-07-27T11:39:25.532Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/11/8a3d16443d157f817975e61f2e97e894a6e2966cfe700cb900a4f16caf9e/pyroscope_io-1.2.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e2ce28485fc46390c31300abde8c93b7dd6c042960deb1b729c2d001a8795516", size = 2112233, upload-time = "2026-07-27T11:39:26.889Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/34/640bcbeb50aec8dac27b4242b349a2a2eeb3c4ab8b62660ae9cb2dbe1cee/pyroscope_io-1.2.1-cp313-cp313-macosx_11_0_x86_64.whl", hash = "sha256:10b0e7a8040ed6b953c9920f2c463d6dddd4f26c01dcb1ffb696879c15cab218", size = 2195244, upload-time = "2026-07-27T11:39:28.397Z" },
+    { url = "https://files.pythonhosted.org/packages/03/07/d3e7c279d44b88e94484453574ff837b0fecae3395a979d4def25b548234/pyroscope_io-1.2.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:655f8629f3f8c5b8c2bec105f0c19a69be4666ae5e452e4c910b2fa3de3452d6", size = 5578633, upload-time = "2026-07-27T11:39:29.805Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/59/9ce4cdafc9a31eda7aeb37c931367c61dab7846b56e396259273efa46e6f/pyroscope_io-1.2.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:e232ea23cc756f6990a325230c6f22d7c380b012a3bd9dac476a338b1edd7d26", size = 5121946, upload-time = "2026-07-27T11:39:31.478Z" },
+    { url = "https://files.pythonhosted.org/packages/19/80/cc8eb25b908e27fc7ef63b007eb226e3c31903fd9886ab18dea1fccda2c6/pyroscope_io-1.2.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:35e57ab13d40d8af15821bc30720eb5c74949c169b649379ad114f7e1f75cd8f", size = 5510621, upload-time = "2026-07-27T11:39:32.939Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/9c/6452ac8356c4f7f11e67a96bc57062b813158e1315fad63ac81008d5ed79/pyroscope_io-1.2.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:31a2a694f507280a451fe082789599e68af48389c74b2c15d99715bd0d0f9f77", size = 5238044, upload-time = "2026-07-27T11:39:34.654Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/ec/dd4911e8a36e40050b14f382489de9bac474e2c02cefaa5e02e04a59edd3/pyroscope_io-1.2.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:152be5e004ca87da17a91c9b80726b78b32d3d4ae3ed0e31117924f76c665c7a", size = 2113631, upload-time = "2026-07-27T11:39:35.953Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/6a/4c4067e7a9cf67329f431db30dffff00fd0cdd4fff013bfa7801ce8eacd0/pyroscope_io-1.2.1-cp314-cp314-macosx_11_0_x86_64.whl", hash = "sha256:95d535c377c43631b1a4d24ac42f3fa81ece7baca4749f23a6cc9db5ff98e477", size = 2196267, upload-time = "2026-07-27T11:39:37.448Z" },
+    { url = "https://files.pythonhosted.org/packages/04/b3/571e0065c8e3b54f36ddbdc9faa79db56647c1bc8d7f0fb28cddcef096ba/pyroscope_io-1.2.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8673378adcf7985b6824cefbdfc8ee2567576d1e70f710b8dda649cb3a90b1ae", size = 5579251, upload-time = "2026-07-27T11:39:38.747Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/7e/908489444509ec91ba0f2d165ba745a0315dcf8eb9a17f55af3b17bec708/pyroscope_io-1.2.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5ec8e2a8954de298000811af743060c2ec85295c452a8b3e0226be11ffaf1c80", size = 5123892, upload-time = "2026-07-27T11:39:40.104Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/17/aeaeb24938460348c9aa7903cfc186d6c1130b0d097fbddc5c9db0dc517f/pyroscope_io-1.2.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:014c6f222cec75eebb12b85ea8ced49efedd29f027dae915e4257822b2815272", size = 5510572, upload-time = "2026-07-27T11:39:41.575Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/07/92941723d8aaca1dbbe0f724da51ff8d02e610353b5e999de97a0547f950/pyroscope_io-1.2.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:83867ba5f46f1d0946524407d5627c1bb06f32dfd35fc06c7258f756d9e80c08", size = 5240581, upload-time = "2026-07-27T11:39:43.217Z" },
+]
+
+[[package]]
 name = "pytest"
 version = "9.1.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2070,6 +2102,9 @@ dependencies = [
 grpc = [
     { name = "opentelemetry-exporter-otlp-proto-grpc" },
 ]
+profiling = [
+    { name = "pyroscope-io" },
+]
 sentry = [
     { name = "structlog-sentry" },
 ]
@@ -2106,10 +2141,11 @@ requires-dist = [
     { name = "opentelemetry-exporter-otlp-proto-grpc", marker = "extra == 'grpc'", specifier = ">=1.19,<2" },
     { name = "opentelemetry-exporter-otlp-proto-http", specifier = ">=1.19,<2" },
     { name = "opentelemetry-sdk", specifier = ">=1.19,<2" },
+    { name = "pyroscope-io", marker = "extra == 'profiling'", specifier = ">=1.2,<2" },
     { name = "python-ipware", specifier = ">=2,<4" },
     { name = "structlog-sentry", marker = "extra == 'sentry'", specifier = ">=2.0.0,<3" },
 ]
-provides-extras = ["grpc", "sentry"]
+provides-extras = ["grpc", "profiling", "sentry"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
Profiling was removed in v7. This brings back the push half only,
configured the way tracing is: an Exporter names the endpoint, a frozen
ProfilerOptions carries the sampling knobs, and configure_profiler wires
them together. Grafana's pyroscope-io SDK does the sampling. It is a
large compiled wheel, so it sits behind a troncos[profiling] extra and
is imported only when profiling is enabled.

Pull mode is not offered. Pyroscope scrapes /debug/pprof, but something
has to produce the pprof bytes and Python has nothing maintained that
does: ddtrace.profiling.exporter is gone as of 4.x, and pypprof,
zprofile and mprofile are abandoned or linux-x86_64 only. v6 produced
them by subclassing ddtrace's private profiler internals, which is the
coupling that broke on upgrade. Supporting pull again would mean owning
a sampler and a pprof encoder, so scrape-based deployments have to move
to push.

The SDK validates nothing, so troncos does. Any configuration that would
start a profiler and collect nothing raises ValueError, and a service
name is required from either the argument or DD_SERVICE, since Pyroscope
groups profiles by it. oncpu and gil_only default to False, opposite to
the SDK, so that time spent waiting is visible.

The tests bind every call against the installed pyroscope.configure
signature, which catches the SDK dropping arguments the way it dropped
auth_token. They never start a profiler, so a change in upload behaviour
rather than signature would not be caught.